### PR TITLE
Handle when FUSION_MAX_MAP_SIZE is not defined. FUSION_MAX_MAP_SIZE is o...

### DIFF
--- a/include/boost/msm/front/euml/common.hpp
+++ b/include/boost/msm/front/euml/common.hpp
@@ -2527,6 +2527,8 @@ static kleene_ kleene;
         BOOST_PP_CAT(instance,_helper) operator()                                               \
         (BOOST_PP_ENUM(n, MSM_EUML_EVENT_INSTANCE_HELPER_EXECUTE1, ~ ))const{                   \
         return BOOST_PP_CAT(instance,_helper) (BOOST_PP_ENUM(n, MSM_EUML_EVENT_INSTANCE_HELPER_EXECUTE2, ~ ));}
+        
+#if defined(FUSION_MAX_MAP_SIZE)
 
 #define BOOST_MSM_EUML_EVENT_WITH_ATTRIBUTES(instance_name, attributes_name)                    \
     struct instance_name ## _helper :                                                           \
@@ -2551,6 +2553,34 @@ static kleene_ kleene;
         MSM_EUML_EVENT_INSTANCE_HELPER_OPERATOR_IMPL, instance_name)                            \
     };                                                                                          \
     static instance_name ## _helper instance_name;
+
+#else
+
+#define BOOST_MSM_EUML_EVENT_WITH_ATTRIBUTES(instance_name, attributes_name)                    \
+    struct instance_name ## _helper :                                                           \
+        boost::msm::front::euml::euml_event<instance_name ## _helper> , public attributes_name  \
+    {                                                                                           \
+        template <class T,int checked_size> struct size_helper                                  \
+        {                                                                                       \
+            typedef typename ::boost::mpl::less_equal<                                          \
+                typename ::boost::fusion::result_of::size<T>::type,                             \
+                ::boost::mpl::int_<checked_size> >::type type;                                  \
+        };                                                                                      \
+        BOOST_PP_CAT(instance_name,_helper()) : attributes_name(){}                             \
+        typedef attributes_name::attributes_type attribute_map;                                 \
+        typedef ::boost::fusion::result_of::as_vector<attribute_map>::type attribute_vec;       \
+        BOOST_PP_REPEAT_FROM_TO(1,BOOST_PP_ADD(10 ,1),                                          \
+        MSM_EUML_EVENT_HELPER_CONSTRUCTORS, (instance_name,attributes_name))                    \
+        BOOST_PP_REPEAT_FROM_TO(1,BOOST_PP_ADD(10 ,1),                                          \
+        MSM_EUML_EVENT_INSTANCE_HELPER_ATTRIBUTE_MAP, ~)                                        \
+        BOOST_PP_CAT(instance_name,_helper) operator()(){                                       \
+        return BOOST_PP_CAT(instance_name,_helper)();}                                          \
+        BOOST_PP_REPEAT_FROM_TO(1,BOOST_PP_ADD(10 ,1),                                          \
+        MSM_EUML_EVENT_INSTANCE_HELPER_OPERATOR_IMPL, instance_name)                            \
+    };                                                                                          \
+    static instance_name ## _helper instance_name;
+
+#endif
 
 #define BOOST_MSM_EUML_EVENT_NAME(instance_name) instance_name ## _helper
 


### PR DESCRIPTION
...nly defined when BOOST_FUSION_HAS_VARIADIC_MAP is not defined. The conditions in which BOOST_FUSION_HAS_VARIADIC_MAP are defined can be seen in the fusion file C:\Programming\VersionControl\modular-boost\libs\fusion\include\boost\fusion\container\map\map_fwd.hpp.
