### PR TITLE
Fix Ticket #11134: Adjust boost::fusion::nil to boost::fusion::nil_

### DIFF
--- a/include/boost/msm/back/state_machine.hpp
+++ b/include/boost/msm/back/state_machine.hpp
@@ -1587,7 +1587,7 @@ private:
      void set_states(Expr const& expr)
      {
          ::boost::fusion::for_each(
-             ::boost::fusion::as_vector(FoldToList()(expr, boost::fusion::nil())),update_state(this->m_substate_list));
+             ::boost::fusion::as_vector(FoldToList()(expr, boost::fusion::nil_())),update_state(this->m_substate_list));
      }
 
      // Construct with the default initial states


### PR DESCRIPTION
Fusion renamed the actual type to 'nil_' back in SVN r81628 in order to make it friendlier to ObjC++ (where "nil" is a keyword, sadly). This patch adjusts accumulators to match.

Ran "b2" in the msm/test directory and things still look good.