### PR TITLE
Bugfix: Deferred and queued event iterative dispatch

### DIFF
--- a/include/boost/msm/back/common_types.hpp
+++ b/include/boost/msm/back/common_types.hpp
@@ -29,6 +29,17 @@ typedef enum
 
 typedef HandledEnum execute_return;
 
+// source of event provided to RTC algorithm
+enum EventSourceEnum
+{
+    EVENT_SOURCE_DEFAULT=0,
+    EVENT_SOURCE_DIRECT=1,
+    EVENT_SOURCE_DEFERRED=2,
+    EVENT_SOURCE_MSG_QUEUE=4
+};
+
+typedef unsigned char EventSource;
+
 }}}
 
 #endif //BOOST_MSM_COMMON_TYPES_H

--- a/include/boost/msm/back/favor_compile_time.hpp
+++ b/include/boost/msm/back/favor_compile_time.hpp
@@ -24,7 +24,7 @@
 #include <boost/msm/back/common_types.hpp>
 #include <boost/msm/back/dispatch_table.hpp>
 
-namespace boost { namespace msm { namespace back 
+namespace boost { namespace msm { namespace back
 {
 
 template <class Fsm>
@@ -38,8 +38,7 @@ struct process_any_event_helper
         if ( ! finished && ::boost::any_cast<Event>(&any_event)!=0)
         {
             finished = true;
-            res = self->process_event_internal(::boost::any_cast<Event>(any_event),false);
- 
+            res = self->process_event_internal(::boost::any_cast<Event>(any_event));
         }
     }
 private:
@@ -66,7 +65,7 @@ private:
     }                                                                                               \
     }}}
 
-struct favor_compile_time 
+struct favor_compile_time
 {
     typedef int compile_policy;
     typedef ::boost::mpl::false_ add_forwarding_rows;
@@ -88,7 +87,7 @@ struct dispatch_table < Fsm, Stt, Event, ::boost::msm::back::favor_compile_time>
     typedef typename generate_state_set<Stt>::type state_list;
     BOOST_STATIC_CONSTANT(int, max_state = ( ::boost::mpl::size<state_list>::value));
 
-    struct chain_row 
+    struct chain_row
     {
         HandledEnum operator()(Fsm& fsm, int region,int state,Event const& evt) const
         {
@@ -127,8 +126,8 @@ struct dispatch_table < Fsm, Stt, Event, ::boost::msm::back::favor_compile_time>
         ,void>::type
         init_event_base_case(Transition const&, ::boost::mpl::true_ const &) const
         {
-            typedef typename create_stt<Fsm>::type stt; 
-            BOOST_STATIC_CONSTANT(int, state_id = 
+            typedef typename create_stt<Fsm>::type stt;
+            BOOST_STATIC_CONSTANT(int, state_id =
                 (get_state_id<stt,typename Transition::current_state_type>::value));
             self->entries[state_id+1].one_state.push_front(reinterpret_cast<cell>(&Transition::execute));
         }
@@ -148,8 +147,8 @@ struct dispatch_table < Fsm, Stt, Event, ::boost::msm::back::favor_compile_time>
         ,void>::type
         init_event_base_case(Transition const&, ::boost::mpl::false_ const &) const
         {
-            typedef typename create_stt<Fsm>::type stt; 
-            BOOST_STATIC_CONSTANT(int, state_id = 
+            typedef typename create_stt<Fsm>::type stt;
+            BOOST_STATIC_CONSTANT(int, state_id =
                 (get_state_id<stt,typename Transition::current_state_type>::value));
             self->entries[state_id+1].one_state.push_front(&Transition::execute);
         }
@@ -174,10 +173,10 @@ struct dispatch_table < Fsm, Stt, Event, ::boost::msm::back::favor_compile_time>
         {
             //only if the transition event is a base of our event is the reinterpret_case safe
             init_event_base_case(tr,
-                ::boost::mpl::bool_< 
+                ::boost::mpl::bool_<
                     ::boost::is_base_of<typename Transition::transition_event,Event>::type::value>() );
         }
-    
+
         dispatch_table* self;
     };
 
@@ -193,29 +192,29 @@ struct dispatch_table < Fsm, Stt, Event, ::boost::msm::back::favor_compile_time>
         template <bool deferred,bool composite, int some_dummy=0>
         struct helper
         {};
-        template <int some_dummy> struct helper<true,false,some_dummy> 
+        template <int some_dummy> struct helper<true,false,some_dummy>
         {
             template <class State>
             static void execute(boost::msm::wrap<State> const&,chain_row* tofill)
             {
-                typedef typename create_stt<Fsm>::type stt; 
+                typedef typename create_stt<Fsm>::type stt;
                 BOOST_STATIC_CONSTANT(int, state_id = (get_state_id<stt,State>::value));
                 cell call_no_transition = &Fsm::defer_transition;
                 tofill[state_id+1].one_state.push_back(call_no_transition);
             }
         };
-        template <int some_dummy> struct helper<true,true,some_dummy> 
+        template <int some_dummy> struct helper<true,true,some_dummy>
         {
             template <class State>
             static void execute(boost::msm::wrap<State> const&,chain_row* tofill)
             {
-                typedef typename create_stt<Fsm>::type stt; 
+                typedef typename create_stt<Fsm>::type stt;
                 BOOST_STATIC_CONSTANT(int, state_id = (get_state_id<stt,State>::value));
                 cell call_no_transition = &Fsm::defer_transition;
                 tofill[state_id+1].one_state.push_back(call_no_transition);
             }
         };
-        template <int some_dummy> struct helper<false,true,some_dummy> 
+        template <int some_dummy> struct helper<false,true,some_dummy>
         {
             template <class State>
             static
@@ -235,18 +234,18 @@ struct dispatch_table < Fsm, Stt, Event, ::boost::msm::back::favor_compile_time>
             ,void>::type
             execute(boost::msm::wrap<State> const&,chain_row* tofill,boost::msm::back::dummy<1> = 0)
             {
-                typedef typename create_stt<Fsm>::type stt; 
+                typedef typename create_stt<Fsm>::type stt;
                 BOOST_STATIC_CONSTANT(int, state_id = (get_state_id<stt,State>::value));
                 cell call_no_transition = &call_submachine< State >;
                 tofill[state_id+1].one_state.push_front(call_no_transition);
             }
         };
-        template <int some_dummy> struct helper<false,false,some_dummy> 
+        template <int some_dummy> struct helper<false,false,some_dummy>
         {
             template <class State>
             static void execute(boost::msm::wrap<State> const&,chain_row* tofill)
             {
-                typedef typename create_stt<Fsm>::type stt; 
+                typedef typename create_stt<Fsm>::type stt;
                 BOOST_STATIC_CONSTANT(int, state_id = (get_state_id<stt,State>::value));
                 cell call_no_transition = &Fsm::call_no_transition;
                 tofill[state_id+1].one_state.push_back(call_no_transition);
@@ -277,7 +276,7 @@ struct dispatch_table < Fsm, Stt, Event, ::boost::msm::back::favor_compile_time>
         template <class State>
         void operator()(boost::msm::wrap<State> const&)
         {
-            typedef typename create_stt<Fsm>::type stt; 
+            typedef typename create_stt<Fsm>::type stt;
             BOOST_STATIC_CONSTANT(int, state_id = (get_state_id<stt,State>::value));
             cell call_no_transition = &Fsm::default_eventless_transition;
             tofill_entries[state_id+1].one_state.push_back(call_no_transition);
@@ -298,7 +297,7 @@ struct dispatch_table < Fsm, Stt, Event, ::boost::msm::back::favor_compile_time>
         (init_cell(this));
 
         ::boost::mpl::for_each<
-            typename generate_state_set<Stt>::type, 
+            typename generate_state_set<Stt>::type,
             boost::msm::wrap< ::boost::mpl::placeholders::_1> >
          (default_init_cell<Event>(this,entries));
 

--- a/include/boost/msm/back/state_machine.hpp
+++ b/include/boost/msm/back/state_machine.hpp
@@ -1874,7 +1874,7 @@ private:
     struct handle_eventless_transitions_helper
     {
         handle_eventless_transitions_helper(library_sm* , bool ){}
-        void process_completion_event(EventSource = 0){}
+        void process_completion_event(EventSource = EVENT_SOURCE_DEFAULT){}
     };
     // otherwise
     template <class StateType>
@@ -1882,7 +1882,7 @@ private:
         <StateType, typename enable_if< typename ::boost::msm::back::has_fsm_eventless_transition<StateType>::type >::type>
     {
         handle_eventless_transitions_helper(library_sm* self_, bool handled_):self(self_),handled(handled_){}
-        void process_completion_event(EventSource source = 0)
+        void process_completion_event(EventSource source = EVENT_SOURCE_DEFAULT)
         {
             typedef typename ::boost::mpl::deref<
                 typename ::boost::mpl::begin<

--- a/include/boost/msm/back/state_machine.hpp
+++ b/include/boost/msm/back/state_machine.hpp
@@ -48,7 +48,7 @@
 #include <boost/any.hpp>
 #endif
 
-#include <boost/serialization/base_object.hpp> 
+#include <boost/serialization/base_object.hpp>
 
 #include <boost/parameter.hpp>
 
@@ -87,7 +87,7 @@ namespace boost { namespace msm { namespace back
 {
 // event used internally for wrapping a direct entry
 template <class StateType,class Event>
-struct direct_entry_event 
+struct direct_entry_event
 {
     typedef int direct_entry;
     typedef StateType active_state;
@@ -110,18 +110,18 @@ BOOST_PARAMETER_TEMPLATE_KEYWORD(queue_container_policy)
 
 typedef ::boost::parameter::parameters<
     ::boost::parameter::required< ::boost::msm::back::tag::front_end >
-  , ::boost::parameter::optional< 
-        ::boost::parameter::deduced< ::boost::msm::back::tag::history_policy>, has_history_policy< ::boost::mpl::_ > 
+  , ::boost::parameter::optional<
+        ::boost::parameter::deduced< ::boost::msm::back::tag::history_policy>, has_history_policy< ::boost::mpl::_ >
     >
-  , ::boost::parameter::optional< 
-        ::boost::parameter::deduced< ::boost::msm::back::tag::compile_policy>, has_compile_policy< ::boost::mpl::_ > 
+  , ::boost::parameter::optional<
+        ::boost::parameter::deduced< ::boost::msm::back::tag::compile_policy>, has_compile_policy< ::boost::mpl::_ >
     >
-  , ::boost::parameter::optional< 
-        ::boost::parameter::deduced< ::boost::msm::back::tag::fsm_check_policy>, has_fsm_check< ::boost::mpl::_ > 
+  , ::boost::parameter::optional<
+        ::boost::parameter::deduced< ::boost::msm::back::tag::fsm_check_policy>, has_fsm_check< ::boost::mpl::_ >
     >
-  , ::boost::parameter::optional< 
-        ::boost::parameter::deduced< ::boost::msm::back::tag::queue_container_policy>, 
-        has_queue_container_policy< ::boost::mpl::_ > 
+  , ::boost::parameter::optional<
+        ::boost::parameter::deduced< ::boost::msm::back::tag::queue_container_policy>,
+        has_queue_container_policy< ::boost::mpl::_ >
     >
 > state_machine_signature;
 
@@ -153,7 +153,7 @@ class state_machine : //public Derived
     , public make_euml_terminal<state_machine<A0,A1,A2,A3,A4>,
                          typename ::boost::parameter::binding<
                                     typename state_machine_signature::bind<A0,A1,A2,A3,A4>::type, ::boost::msm::back::tag::front_end
-                         >::type   
+                         >::type
       >
 {
 public:
@@ -176,10 +176,10 @@ public:
         state_machine_args, ::boost::msm::back::tag::fsm_check_policy, no_fsm_check >::type         FsmCheckPolicy;
 
     typedef typename ::boost::parameter::binding<
-        state_machine_args, ::boost::msm::back::tag::queue_container_policy, 
+        state_machine_args, ::boost::msm::back::tag::queue_container_policy,
         queue_container_deque >::type                                                               QueueContainerPolicy;
 
-private: 
+private:
 
     typedef boost::msm::back::state_machine<
         A0,A1,A2,A3,A4>                             library_sm;
@@ -189,8 +189,8 @@ private:
     typedef ::boost::function<
         execute_return () >                         deferred_fct;
     typedef typename QueueContainerPolicy::
-        template In< 
-        std::pair<deferred_fct,bool> >::type        deferred_events_queue_t;
+        template In<
+            std::pair<deferred_fct,char> >::type    deferred_events_queue_t;
     typedef typename QueueContainerPolicy::
         template In<transition_fct>::type           events_queue_t;
 
@@ -210,7 +210,7 @@ private:
     // helper to add, if needed, visitors to all states
     // version without visitors
     template <class StateType,class Enable=void>
-    struct visitor_fct_helper 
+    struct visitor_fct_helper
     {
     public:
         visitor_fct_helper(){}
@@ -228,7 +228,7 @@ private:
     };
     // version with visitors
     template <class StateType>
-    struct visitor_fct_helper<StateType,typename ::boost::enable_if<has_accept_sig<StateType> >::type> 
+    struct visitor_fct_helper<StateType,typename ::boost::enable_if<has_accept_sig<StateType> >::type>
     {
     public:
         visitor_fct_helper():m_state_visitors(){}
@@ -265,25 +265,26 @@ private:
     };
 
     template <class StateType,class Enable=int>
-    struct deferred_msg_queue_helper 
+    struct deferred_msg_queue_helper
     {
         void clear(){}
     };
     template <class StateType>
     struct deferred_msg_queue_helper<StateType,
-        typename ::boost::enable_if< 
-            typename ::boost::msm::back::has_fsm_deferred_events<StateType>::type,int >::type> 
+        typename ::boost::enable_if<
+            typename ::boost::msm::back::has_fsm_deferred_events<StateType>::type,int >::type>
     {
     public:
-        deferred_msg_queue_helper():m_deferred_events_queue(){}
+        deferred_msg_queue_helper():m_deferred_events_queue(),m_cur_seq(0){}
         void clear()
         {
             m_deferred_events_queue.clear();
         }
         deferred_events_queue_t         m_deferred_events_queue;
+        char m_cur_seq;
     };
 
- public: 
+ public:
     // tags
     typedef int composite_tag;
 
@@ -305,14 +306,14 @@ private:
     typedef Derived                             ConcreteSM;
 
     // if the front-end fsm provides an initial_event typedef, replace InitEvent by this one
-    typedef typename ::boost::mpl::eval_if< 
+    typedef typename ::boost::mpl::eval_if<
         typename has_initial_event<Derived>::type,
         get_initial_event<Derived>,
         ::boost::mpl::identity<InitEvent>
     >::type fsm_initial_event;
 
     // if the front-end fsm provides an exit_event typedef, replace ExitEvent by this one
-    typedef typename ::boost::mpl::eval_if< 
+    typedef typename ::boost::mpl::eval_if<
         typename has_final_event<Derived>::type,
         get_final_event<Derived>,
         ::boost::mpl::identity<ExitEvent>
@@ -326,7 +327,7 @@ private:
         typedef int                 pseudo_exit;
         typedef library_sm          owner;
         typedef int                 no_automatic_create;
-        typedef typename 
+        typedef typename
             ExitPoint::event        Event;
         typedef ::boost::function<execute_return (Event const&)>
                                     forwarding_function;
@@ -341,15 +342,15 @@ private:
         void set_forward_fct(::boost::function<execute_return (Event const&)> fct)
         {
             m_forward = fct;
-        }    
+        }
         exit_pt():m_forward(){}
         // by assignments, we keep our forwarding functor unchanged as our containing SM did not change
     template <class RHS>
         exit_pt(RHS&):m_forward(){}
-        exit_pt<ExitPoint>& operator= (const exit_pt<ExitPoint>& ) 
-        { 
-            return *this; 
-        } 
+        exit_pt<ExitPoint>& operator= (const exit_pt<ExitPoint>& )
+        {
+            return *this;
+        }
     private:
          forwarding_function          m_forward;
 
@@ -444,7 +445,7 @@ private:
             BOOST_STATIC_CONSTANT(int, next_state = (get_state_id<stt,next_state_type>::type::value));
             BOOST_ASSERT(state == (current_state));
             // if T1 is an exit pseudo state, then take the transition only if the pseudo exit state is active
-            if (has_pseudo_exit<T1>::type::value && 
+            if (has_pseudo_exit<T1>::type::value &&
                 !is_exit_state_active<T1,get_owner<T1,library_sm> >(fsm))
             {
                 return HANDLED_FALSE;
@@ -523,7 +524,7 @@ private:
             BOOST_STATIC_CONSTANT(int, next_state = (get_state_id<stt,next_state_type>::type::value));
             BOOST_ASSERT(state == (current_state));
             // if T1 is an exit pseudo state, then take the transition only if the pseudo exit state is active
-            if (has_pseudo_exit<T1>::type::value && 
+            if (has_pseudo_exit<T1>::type::value &&
                 !is_exit_state_active<T1,get_owner<T1,library_sm> >(fsm))
             {
                 return HANDLED_FALSE;
@@ -553,7 +554,7 @@ private:
     template<
         typename ROW
     >
-    struct a_row_ 
+    struct a_row_
     {
         //typedef typename ROW::Source T1;
         typedef typename make_entry<typename ROW::Source,library_sm>::type T1;
@@ -587,7 +588,7 @@ private:
             BOOST_ASSERT(state == (current_state));
 
             // if T1 is an exit pseudo state, then take the transition only if the pseudo exit state is active
-            if (has_pseudo_exit<T1>::type::value && 
+            if (has_pseudo_exit<T1>::type::value &&
                 !is_exit_state_active<T1,get_owner<T1,library_sm> >(fsm))
             {
                 return HANDLED_FALSE;
@@ -653,7 +654,7 @@ private:
             BOOST_ASSERT(state == (current_state));
 
             // if T1 is an exit pseudo state, then take the transition only if the pseudo exit state is active
-            if (has_pseudo_exit<T1>::type::value && 
+            if (has_pseudo_exit<T1>::type::value &&
                 !is_exit_state_active<T1,get_owner<T1,library_sm> >(fsm))
             {
                 return HANDLED_FALSE;
@@ -757,7 +758,7 @@ private:
     template<
         typename ROW
     >
-    struct a_irow_ 
+    struct a_irow_
     {
         typedef typename make_entry<typename ROW::Source,library_sm>::type T1;
         typedef typename make_exit<typename ROW::Target,library_sm>::type T2;
@@ -785,7 +786,7 @@ private:
     template<
         typename ROW
     >
-    struct _irow_ 
+    struct _irow_
     {
         typedef typename make_entry<typename ROW::Source,library_sm>::type T1;
         typedef typename make_exit<typename ROW::Target,library_sm>::type T2;
@@ -1022,8 +1023,8 @@ private:
         static HandledEnum execute(library_sm& fsm, int region_index, int , transition_event const& evt)
         {
             // false as second parameter because this event is forwarded from outer fsm
-            execute_return res = 
-                (::boost::fusion::at_key<current_state_type>(fsm.m_substate_list)).process_event_internal(evt,false); 
+            execute_return res =
+                (::boost::fusion::at_key<current_state_type>(fsm.m_substate_list)).process_event_internal(evt);
             fsm.m_states[region_index]=get_state_id<stt,T1>::type::value;
             return res;
         }
@@ -1109,7 +1110,7 @@ private:
 
     // add to the stt the initial states which could be missing (if not being involved in a transition)
     template <class BaseType, class stt_simulated = typename BaseType::transition_table>
-    struct create_real_stt 
+    struct create_real_stt
     {
         //typedef typename BaseType::transition_table stt_simulated;
         typedef typename ::boost::mpl::fold<
@@ -1145,7 +1146,7 @@ private:
                                              make_row_tag< ::boost::mpl::placeholders::_2 , StateType> >
                 >::type recursive_istt_with_tag;
 
-        typedef typename ::boost::mpl::insert_range< original_table, typename ::boost::mpl::end<original_table>::type, 
+        typedef typename ::boost::mpl::insert_range< original_table, typename ::boost::mpl::end<original_table>::type,
                                                      recursive_istt_with_tag>::type table_with_all_events;
 
         // and add for every event a forwarding row
@@ -1200,12 +1201,12 @@ private:
         // for every state, add its transition table (if any)
         // transformed as frow
         typedef typename ::boost::mpl::fold<state_list,stt_plus_internal,
-                ::boost::mpl::insert_range< 
-                        ::boost::mpl::placeholders::_1, 
+                ::boost::mpl::insert_range<
+                        ::boost::mpl::placeholders::_1,
                         ::boost::mpl::end< ::boost::mpl::placeholders::_1>,
-                        get_internal_transition_table< 
+                        get_internal_transition_table<
                                 ::boost::mpl::placeholders::_2,
-                                is_composite_state< ::boost::mpl::placeholders::_2> > > 
+                                is_composite_state< ::boost::mpl::placeholders::_2> > >
         >::type type;
     };
     // extend the table with tables from composite states
@@ -1262,17 +1263,19 @@ private:
     template<class Event>
     execute_return process_event(Event const& evt)
     {
-        return process_event_internal(evt,true);
+        return process_event_internal(evt, EVENT_SOURCE_DIRECT);
     }
 
     template <class EventType>
     void enqueue_event_helper(EventType const& evt, ::boost::mpl::false_ const &)
     {
-        execute_return (library_sm::*pf) (EventType const& evt) = 
-            &library_sm::process_event; 
+        execute_return (library_sm::*pf) (EventType const&, EventSource) =
+            &library_sm::process_event_internal;
 
-        transition_fct f = ::boost::bind(pf,this,evt);
-        m_events_queue.m_events_queue.push_back(f);
+        m_events_queue.m_events_queue.push_back(
+            ::boost::bind(
+                pf, this, evt,
+                EVENT_SOURCE_MSG_QUEUE));
     }
     template <class EventType>
     void enqueue_event_helper(EventType const& , ::boost::mpl::true_ const &)
@@ -1364,24 +1367,24 @@ private:
         serialize_state(Archive& ar):ar_(ar){}
 
         template<typename T>
-        typename ::boost::enable_if< 
+        typename ::boost::enable_if<
             typename ::boost::mpl::or_<
                 typename has_do_serialize<T>::type,
                 typename is_composite_state<T>::type
             >::type
-            ,void 
+            ,void
         >::type
         operator()(T& t) const
         {
             ar_ & t;
         }
         template<typename T>
-        typename ::boost::disable_if< 
+        typename ::boost::disable_if<
             typename ::boost::mpl::or_<
                 typename has_do_serialize<T>::type,
                 typename is_composite_state<T>::type
             >::type
-            ,void 
+            ,void
         >::type
         operator()(T&) const
         {
@@ -1389,11 +1392,11 @@ private:
         }
         Archive& ar_;
     };
-    
+
     template<class Archive>
     void serialize(Archive & ar, const unsigned int)
     {
-        // invoke serialization of the base class 
+        // invoke serialization of the base class
         (serialize_state<Archive>(ar))(boost::serialization::base_object<Derived>(*this));
         // now our attributes
         ar & m_states;
@@ -1406,7 +1409,7 @@ private:
     }
 
     // linearly search for the state with the given id
-    struct get_state_id_helper 
+    struct get_state_id_helper
     {
         get_state_id_helper(int id,const BaseState** res,const library_sm* self_):
         result_state(res),searched_id(id),self(self_) {}
@@ -1431,7 +1434,7 @@ private:
     BaseState* get_state_by_id(int id)
     {
         const BaseState*  result_state=0;
-        ::boost::mpl::for_each<state_list, 
+        ::boost::mpl::for_each<state_list,
             ::boost::msm::wrap< ::boost::mpl::placeholders::_1> > (get_state_id_helper(id,&result_state,this));
         return const_cast<BaseState*>(result_state);
     }
@@ -1482,7 +1485,7 @@ private:
     typename ::boost::enable_if<typename ::boost::is_pointer<State>::type,State >::type
     get_state(::boost::msm::back::dummy<0> = 0)
     {
-        return &(static_cast<typename boost::add_reference<typename ::boost::remove_pointer<State>::type>::type > 
+        return &(static_cast<typename boost::add_reference<typename ::boost::remove_pointer<State>::type>::type >
         (::boost::fusion::at_key<typename ::boost::remove_pointer<State>::type>(m_substate_list)));
     }
     // as a reference
@@ -1500,7 +1503,7 @@ private:
         bool res = (*flags_entries[ m_states[0] ])(*this);
         for (int i = 1; i < nr_regions::value ; ++i)
         {
-            res = typename BinaryOp::type() (res,(*flags_entries[ m_states[i] ])(*this)); 
+            res = typename BinaryOp::type() (res,(*flags_entries[ m_states[i] ])(*this));
         }
         return res;
     }
@@ -1540,10 +1543,17 @@ private:
         // to call this function, you need either a state with a deferred_events typedef
         // or that the fsm provides the activate_deferred_events typedef
         BOOST_MPL_ASSERT(( has_fsm_deferred_events<library_sm> ));
-        execute_return (library_sm::*pf) (Event const& evt)= &library_sm::process_event;
-        Event temp (e);
-        ::boost::function<execute_return () > f= ::boost::bind(pf, this,temp);
-        post_deferred_event(f);
+        execute_return (library_sm::*pf) (Event const&, EventSource) =
+            &library_sm::process_event_internal;
+
+        // Deferred events are added with a correlation sequence that helps to
+        // identify when an event was added - This is typically to distinguish
+        // between events deferred in this processing versus previous.
+        m_deferred_events_queue.m_deferred_events_queue.push_back(
+            std::make_pair(
+                ::boost::bind(
+                    pf, this, e, (EVENT_SOURCE_DIRECT|EVENT_SOURCE_DEFERRED)),
+                m_deferred_events_queue.m_cur_seq+1));
     }
 
  protected:    // interface for the derived class
@@ -1576,14 +1586,14 @@ private:
      template <class Expr>
      void set_states(Expr const& expr)
      {
-         ::boost::fusion::for_each( 
+         ::boost::fusion::for_each(
              ::boost::fusion::as_vector(FoldToList()(expr, boost::fusion::nil())),update_state(this->m_substate_list));
      }
 
      // Construct with the default initial states
      state_machine<A0,A1,A2,A3,A4 >()
          :Derived()
-         ,m_events_queue() 
+         ,m_events_queue()
          ,m_deferred_events_queue()
          ,m_history()
          ,m_event_processing(false)
@@ -1602,7 +1612,7 @@ private:
      state_machine<A0,A1,A2,A3,A4 >
          (Expr const& expr,typename ::boost::enable_if<typename ::boost::proto::is_expr<Expr>::type >::type* =0)
          :Derived()
-         ,m_events_queue() 
+         ,m_events_queue()
          ,m_deferred_events_queue()
          ,m_history()
          ,m_event_processing(false)
@@ -1677,18 +1687,18 @@ private:
      // assignment operator using the copy policy to decide if non_copyable, shallow or deep copying is necessary
      library_sm& operator= (library_sm const& rhs)
      {
-         if (this != &rhs) 
+         if (this != &rhs)
          {
             Derived::operator=(rhs);
             do_copy(rhs);
          }
         return *this;
      }
-     state_machine<A0,A1,A2,A3,A4> 
+     state_machine<A0,A1,A2,A3,A4>
          (library_sm const& rhs)
          : Derived(rhs)
      {
-        if (this != &rhs) 
+        if (this != &rhs)
         {
             // initialize our list of states with the ones defined in Derived::initial_state
             fill_states(this);
@@ -1706,7 +1716,7 @@ private:
             return true;
         // if the state machine is interrupted, do not handle any event
         // unless the event is the end interrupt event
-        if ( is_flag_active< ::boost::msm::InterruptedFlag>() && 
+        if ( is_flag_active< ::boost::msm::InterruptedFlag>() &&
             !is_flag_active< ::boost::msm::EndInterruptFlag<Event> >())
             return true;
         return false;
@@ -1728,16 +1738,21 @@ private:
     template <class StateType,class EventType>
     bool do_pre_msg_queue_helper(EventType const& evt, ::boost::mpl::false_ const &)
     {
-        execute_return (library_sm::*pf) (EventType const& evt) = 
-            &library_sm::process_event; 
+        execute_return (library_sm::*pf) (EventType const&, EventSource) =
+            &library_sm::process_event_internal;
+
         // if we are already processing an event
         if (m_event_processing)
         {
             // event has to be put into the queue
-            transition_fct f = ::boost::bind(pf,this,evt);
-            m_events_queue.m_events_queue.push_back(f);
+            m_events_queue.m_events_queue.push_back(
+                ::boost::bind(
+                    pf, this, evt,
+                    EVENT_SOURCE_DIRECT | EVENT_SOURCE_MSG_QUEUE));
+
             return false;
         }
+
         // event can be handled, processing
         m_event_processing = true;
         return true;
@@ -1785,8 +1800,8 @@ private:
     template <class StateType,class EventType>
     HandledEnum do_process_helper(EventType const& evt, ::boost::mpl::false_ const &, bool is_direct_call)
     {
-        // when compiling without exception support there is no formal parameter "e" in the catch handler. 
-        // Declaring a local variable here does not hurt and will be "used" to make the code in the handler 
+        // when compiling without exception support there is no formal parameter "e" in the catch handler.
+        // Declaring a local variable here does not hurt and will be "used" to make the code in the handler
         // compilable although the code will never be executed.
         std::exception e;
         BOOST_TRY
@@ -1803,15 +1818,11 @@ private:
     }
     // handling of deferred events
     // if none is found in the SM, take the following empty main version
-    template <class StateType, class Enable = int> 
+    template <class StateType, class Enable = int>
     struct handle_defer_helper
     {
         handle_defer_helper(deferred_msg_queue_helper<library_sm>& ){}
-        void do_pre_handle_deferred()
-        {
-        }
-
-        void do_post_handle_deferred(HandledEnum)
+        void do_handle_deferred(bool)
         {
         }
     };
@@ -1821,66 +1832,57 @@ private:
         <StateType, typename enable_if< typename ::boost::msm::back::has_fsm_deferred_events<StateType>::type,int >::type>
     {
         handle_defer_helper(deferred_msg_queue_helper<library_sm>& a_queue):
-            events_queue(a_queue),next_deferred_event(){}
-        void do_pre_handle_deferred()
+            m_events_queue(a_queue) {}
+        void do_handle_deferred(bool new_seq=false)
         {
-        }
-
-        void do_post_handle_deferred(HandledEnum handled)
-        {
-            if (handled & HANDLED_TRUE)
+            // A new sequence is typically started upon initial entry to the
+            // state, or upon a new transition.  When this occurs we want to
+            // process all previously deferred events by incrementing the
+            // correlation sequence.
+            if (new_seq)
             {
-                // a transition has been taken, it makes sense again to try processing waiting deferred events
-                // reset all events to not tested 
-                for (std::size_t i = 0; i < events_queue.m_deferred_events_queue.size(); ++i)
-                {
-                    events_queue.m_deferred_events_queue[i].second=false;
-                }
-                // test first event
-                if (!events_queue.m_deferred_events_queue.empty())
-                {
-                    deferred_fct next = events_queue.m_deferred_events_queue.front().first;
-                    events_queue.m_deferred_events_queue.pop_front();
-                    next();
-                }
+                ++m_events_queue.m_cur_seq;
             }
-            else
+
+            char& cur_seq = m_events_queue.m_cur_seq;
+
+            // Iteratively process all of the events within the deferred
+            // queue upto (but not including) newly deferred events.
+            while (!m_events_queue.m_deferred_events_queue.empty())
             {
-                // look for next deferred event, if any
-                typename deferred_events_queue_t::iterator it = 
-                    std::find_if(events_queue.m_deferred_events_queue.begin(),
-                                 events_queue.m_deferred_events_queue.end(),
-                                 boost::bind(&std::pair<deferred_fct,bool>::second, _1) == false);
-                if (it != events_queue.m_deferred_events_queue.end())
+                typename deferred_events_queue_t::value_type& pair =
+                    m_events_queue.m_deferred_events_queue.front();
+
+                if (cur_seq != pair.second)
                 {
-                    (*it).second = true;
-                    deferred_fct next = (*it).first;
-                    events_queue.m_deferred_events_queue.erase(it);
-                    next();
+                    break;
                 }
+
+                deferred_fct next = pair.first;
+                m_events_queue.m_deferred_events_queue.pop_front();
+                next();
             }
         }
 
     private:
-        deferred_msg_queue_helper<library_sm>&  events_queue;
-        deferred_fct                            next_deferred_event;
+        deferred_msg_queue_helper<library_sm>& m_events_queue;
     };
 
     // handling of eventless transitions
     // if none is found in the SM, nothing to do
-    template <class StateType, class Enable = void> 
+    template <class StateType, class Enable = void>
     struct handle_eventless_transitions_helper
     {
         handle_eventless_transitions_helper(library_sm* , bool ){}
-        void process_completion_event(){}
+        void process_completion_event(EventSource = 0){}
     };
-    // otherwise 
+    // otherwise
     template <class StateType>
     struct handle_eventless_transitions_helper
         <StateType, typename enable_if< typename ::boost::msm::back::has_fsm_eventless_transition<StateType>::type >::type>
     {
         handle_eventless_transitions_helper(library_sm* self_, bool handled_):self(self_),handled(handled_){}
-        void process_completion_event()
+        void process_completion_event(EventSource source = 0)
         {
             typedef typename ::boost::mpl::deref<
                 typename ::boost::mpl::begin<
@@ -1889,10 +1891,12 @@ private:
             >::type first_completion_event;
             if (handled)
             {
-                self->process_event(first_completion_event() );
+                self->process_event_internal(
+                    first_completion_event(),
+                    source | EVENT_SOURCE_DIRECT);
             }
         }
- 
+
     private:
         library_sm* self;
         bool        handled;
@@ -1928,7 +1932,7 @@ private:
     };
 
     template <class StateType,class Enable=void>
-    struct region_processing_helper 
+    struct region_processing_helper
     {
     public:
         region_processing_helper(library_sm* self_,HandledEnum& result_)
@@ -1951,8 +1955,8 @@ private:
     };
     // version with visitors
     template <class StateType>
-    struct region_processing_helper<StateType,typename ::boost::enable_if< 
-                        ::boost::mpl::is_sequence<typename StateType::initial_state> >::type> 
+    struct region_processing_helper<StateType,typename ::boost::enable_if<
+                        ::boost::mpl::is_sequence<typename StateType::initial_state> >::type>
     {
         private:
         // process event in one region
@@ -1999,52 +2003,64 @@ private:
     // Main function used internally to make transitions
     // Can only be called for internally (for example in an action method) generated events.
     template<class Event>
-    execute_return process_event_internal(Event const& evt, bool is_direct_call)
+    execute_return process_event_internal(Event const& evt,
+                                          EventSource source = EVENT_SOURCE_DEFAULT)
     {
-        HandledEnum ret_handled=HANDLED_FALSE;
         // if the state machine has terminate or interrupt flags, check them, otherwise skip
         if (is_event_handling_blocked_helper<Event>
                 ( ::boost::mpl::bool_<has_fsm_blocking_states<library_sm>::type::value>() ) )
+        {
             return HANDLED_TRUE;
+        }
+
         // if a message queue is needed and processing is on the way
         if (!do_pre_msg_queue_helper<Event>
-                (evt,::boost::mpl::bool_<is_no_message_queue<library_sm>::type::value>()) )
+                (evt,::boost::mpl::bool_<is_no_message_queue<library_sm>::type::value>()))
         {
             // wait for the end of current processing
             return HANDLED_TRUE;
         }
         else
         {
-            // prepare the next deferred event for handling
-            // if one defer is found in the SM, otherwise skip
-            handle_defer_helper<library_sm> defer_helper(m_deferred_events_queue);
-            defer_helper.do_pre_handle_deferred();
-            // process event
-            HandledEnum handled = this->do_process_helper<Event>
-                (evt,::boost::mpl::bool_<is_no_exception_thrown<library_sm>::type::value>(),is_direct_call);
-            if (handled)
-            {
-                ret_handled = handled;
-            }
+            // Process event
+            HandledEnum handled = this->do_process_helper<Event>(
+                evt,
+                ::boost::mpl::bool_<is_no_exception_thrown<library_sm>::type::value>(),
+                (EVENT_SOURCE_DIRECT & source));
+
             // at this point we allow the next transition be executed without enqueing
             // so that completion events and deferred events execute now (if any)
-            do_allow_event_processing_after_transition(::boost::mpl::bool_<is_no_message_queue<library_sm>::type::value>(),
-                                                       ::boost::mpl::bool_<has_no_bugfix_wrong_event_order<library_sm>::type::value>());
+            do_allow_event_processing_after_transition(
+                ::boost::mpl::bool_<is_no_message_queue<library_sm>::type::value>(),
+                ::boost::mpl::bool_<has_no_bugfix_wrong_event_order<library_sm>::type::value>());
 
-            // process completion transitions BEFORE any other event in the pool (UML Standard 2.3 15.3.14)
-            handle_eventless_transitions_helper<library_sm> eventless_helper(this,(handled & HANDLED_TRUE));
-            eventless_helper.process_completion_event();
+            // Process completion transitions BEFORE any other event in the
+            // pool (UML Standard 2.3 15.3.14)
+            handle_eventless_transitions_helper<library_sm>
+                eventless_helper(this,(HANDLED_TRUE & handled));
+            eventless_helper.process_completion_event(source);
 
-            // after handling, take care of the deferred events
-            defer_helper.do_post_handle_deferred(handled);
+            // After handling, take care of the deferred events, but only if
+            // we're not already processing from the deferred queue.
+            if (!(EVENT_SOURCE_DEFERRED & source))
+            {
+                handle_defer_helper<library_sm> defer_helper(m_deferred_events_queue);
+                defer_helper.do_handle_deferred(HANDLED_TRUE & handled);
 
-            // now check if some events were generated in a transition and was not handled
-            // because of another processing, and if yes, start handling them
-            do_post_msg_queue_helper(::boost::mpl::bool_<is_no_message_queue<library_sm>::type::value>(),
-                                     ::boost::mpl::bool_<has_no_bugfix_wrong_event_order<library_sm>::type::value>());
+                // Handle any new events generated into the queue, but only if
+                // we're not already processing from the message queue.
+                if (!(EVENT_SOURCE_MSG_QUEUE & source))
+                {
+                    do_post_msg_queue_helper(
+                        ::boost::mpl::bool_<
+                            is_no_message_queue<library_sm>::type::value>(),
+                        ::boost::mpl::bool_<
+                            has_no_bugfix_wrong_event_order<library_sm>::type::value>());
+                }
+            }
 
-            return ret_handled;
-        }       
+            return handled;
+        }
     }
 
     // minimum event processing without exceptions, queues, etc.
@@ -2052,14 +2068,15 @@ private:
     HandledEnum do_process_event(Event const& evt, bool is_direct_call)
     {
         HandledEnum handled = HANDLED_FALSE;
+
         // dispatch the event to every region
         region_processing_helper<Derived> helper(this,handled);
         helper.process(evt);
 
         // if the event has not been handled and we have orthogonal zones, then
-        // generate an error on every active state 
+        // generate an error on every active state
         // for state machine states contained in other state machines, do not handle
-        // but let the containing sm handle the error, unless the event was generated in this fsm 
+        // but let the containing sm handle the error, unless the event was generated in this fsm
         // (by calling process_event on this fsm object, is_direct_call == true)
         // completion events do not produce an error
         if ( (!is_contained() || is_direct_call) && !handled && !is_completion_event<Event>::type::value)
@@ -2121,7 +2138,7 @@ private:
     };
     // helper for flag handling. Uses OR by default on orthogonal zones.
     template <class Flag,bool orthogonalStates>
-    struct FlagHelper 
+    struct FlagHelper
     {
         static bool helper(library_sm const& sm,flag_handler* )
         {
@@ -2187,7 +2204,6 @@ private:
         {
             typedef typename get_flag_list<StateType>::type flags;
             typedef typename ::boost::mpl::contains<flags,Flag >::type found;
-            typedef typename is_composite_state<StateType>::type composite;
 
             BOOST_STATIC_CONSTANT(int, state_id = (get_state_id<stt,StateType>::type::value));
             if (found::type::value)
@@ -2322,9 +2338,9 @@ BOOST_PP_REPEAT(BOOST_PP_ADD(BOOST_MSM_VISITOR_ARG_SIZE,1), MSM_VISITOR_ARGS_EXE
         typename ::boost::enable_if<typename is_pseudo_exit<StateType>::type,void >::type
         new_state_helper( ::boost::msm::back::dummy<2> = 0) const
         {
-            execute_return (ContainingSM::*pf) (typename StateType::event const& evt)= 
+            execute_return (ContainingSM::*pf) (typename StateType::event const& evt)=
                 &ContainingSM::process_event;
-            ::boost::function<execute_return (typename StateType::event const&)> fct = 
+            ::boost::function<execute_return (typename StateType::event const&)> fct =
                 ::boost::bind(pf,containing_sm,_1);
             ::boost::fusion::at_key<StateType>(self->m_substate_list).set_forward_fct(fct);
         }
@@ -2426,7 +2442,7 @@ BOOST_PP_REPEAT(BOOST_PP_ADD(BOOST_MSM_VISITOR_ARG_SIZE,1), MSM_VISITOR_ARGS_EXE
 
      // helper used to call the correct entry/exit method
      // unfortunately in O(number of states in the sub-sm) but should be better than a virtual call
-     template<class Event,bool is_entry> 
+     template<class Event,bool is_entry>
      struct entry_exit_helper
      {
          entry_exit_helper(int id,Event const& e,library_sm* self_):
@@ -2497,7 +2513,7 @@ BOOST_PP_REPEAT(BOOST_PP_ADD(BOOST_MSM_VISITOR_ARG_SIZE,1), MSM_VISITOR_ARGS_EXE
      }
 
      template <class StateType>
-     struct find_region_id 
+     struct find_region_id
      {
          template <int region,int Dummy=0>
          struct In
@@ -2510,14 +2526,14 @@ BOOST_PP_REPEAT(BOOST_PP_ADD(BOOST_MSM_VISITOR_ARG_SIZE,1), MSM_VISITOR_ARGS_EXE
          {
              typedef typename build_orthogonal_regions<
                  library_sm,
-                 initial_states 
+                 initial_states
              >::type all_regions;
              enum {region_index= find_region_index<all_regions,StateType>::value };
-         };         
+         };
          enum {region_index = In<StateType::zone_index>::region_index };
      };
      // helper used to set the correct state as active state upon entry into a fsm
-     struct direct_event_start_helper 
+     struct direct_event_start_helper
      {
          direct_event_start_helper(library_sm* self_):self(self_){}
          // this variant is for the standard case, entry due to activation of the containing FSM
@@ -2537,7 +2553,7 @@ BOOST_PP_REPEAT(BOOST_PP_ADD(BOOST_MSM_VISITOR_ARG_SIZE,1), MSM_VISITOR_ARGS_EXE
                                     typename EventType::active_state>::type >::type,
                         typename ::boost::mpl::and_<typename has_direct_entry<EventType>::type,
                                                     typename ::boost::mpl::not_<typename ::boost::mpl::is_sequence
-                                                            <typename EventType::active_state>::type >::type 
+                                                            <typename EventType::active_state>::type >::type
                                                     >::type>::type,void
                                   >::type
          operator()(EventType const& evt,FsmType& fsm, ::boost::msm::back::dummy<1> = 0)
@@ -2559,13 +2575,13 @@ BOOST_PP_REPEAT(BOOST_PP_ADD(BOOST_MSM_VISITOR_ARG_SIZE,1), MSM_VISITOR_ARGS_EXE
                                     typename is_pseudo_entry<typename EventType::active_state>::type >::type,
                     typename ::boost::mpl::and_<typename has_direct_entry<EventType>::type,
                                                 typename ::boost::mpl::is_sequence<
-                                                                typename EventType::active_state>::type 
-                                                >::type>::type,void 
+                                                                typename EventType::active_state>::type
+                                                >::type>::type,void
                                 >::type
          operator()(EventType const& evt,FsmType& fsm, ::boost::msm::back::dummy<2> = 0)
          {
              (static_cast<Derived*>(self))->on_entry(evt,fsm);
-             ::boost::mpl::for_each<typename EventType::active_state, 
+             ::boost::mpl::for_each<typename EventType::active_state,
                                     ::boost::msm::wrap< ::boost::mpl::placeholders::_1> >
                                                         (fork_helper<EventType>(self,evt));
              // set the correct zones, the others (if any) will be default/history initialized
@@ -2620,7 +2636,7 @@ BOOST_PP_REPEAT(BOOST_PP_ADD(BOOST_MSM_VISITOR_ARG_SIZE,1), MSM_VISITOR_ARGS_EXE
          template<class Event>
          static void do_entry(library_sm* self_,Event const& incomingEvent)
          {
-             self_->m_states[region_id::value] = 
+             self_->m_states[region_id::value] =
                  self_->m_history.history_entry(incomingEvent)[region_id::value];
              region_entry_exit_helper
                  < ::boost::mpl::int_<region_id::value+1> >::do_entry(self_,incomingEvent);
@@ -2657,7 +2673,7 @@ BOOST_PP_REPEAT(BOOST_PP_ADD(BOOST_MSM_VISITOR_ARG_SIZE,1), MSM_VISITOR_ARGS_EXE
         m_event_processing = false;
         // look for deferred events waiting
         handle_defer_helper<library_sm> defer_helper(m_deferred_events_queue);
-        defer_helper.do_post_handle_deferred(HANDLED_TRUE);
+        defer_helper.do_handle_deferred(true);
         process_message_queue(this);
      }
      template <class Event,class FsmType>
@@ -2712,25 +2728,21 @@ BOOST_PP_REPEAT(BOOST_PP_ADD(BOOST_MSM_VISITOR_ARG_SIZE,1), MSM_VISITOR_ARGS_EXE
 #if defined (__IBMCPP__) || (defined(_MSC_VER) && (_MSC_VER < 1400))
      private:
 #endif
-    // puts a deferred event in the queue
-    void post_deferred_event(deferred_fct& deferred)
-    {
-        m_deferred_events_queue.m_deferred_events_queue.push_back(std::make_pair(deferred,true));
-    }
     // removes one event from the message queue and processes it
     template <class StateType>
-    void process_message_queue(StateType*, 
+    void process_message_queue(StateType*,
                                typename ::boost::disable_if<typename is_no_message_queue<StateType>::type,void >::type* = 0)
     {
-        if (!m_events_queue.m_events_queue.empty())
+        // Iteratively process all events from the message queue.
+        while (!m_events_queue.m_events_queue.empty())
         {
-            transition_fct to_call = m_events_queue.m_events_queue.front();
+            transition_fct next = m_events_queue.m_events_queue.front();
             m_events_queue.m_events_queue.pop_front();
-            to_call();
+            next();
         }
     }
     template <class StateType>
-    void process_message_queue(StateType*, 
+    void process_message_queue(StateType*,
                                typename ::boost::enable_if<typename is_no_message_queue<StateType>::type,void >::type* = 0)
     {
         // nothing to process
@@ -2738,7 +2750,7 @@ BOOST_PP_REPEAT(BOOST_PP_ADD(BOOST_MSM_VISITOR_ARG_SIZE,1), MSM_VISITOR_ARGS_EXE
     // helper function. In cases where the event is wrapped (target is a direct entry states)
     // we want to send only the real event to on_entry, not the wrapper.
     template <class EventType>
-    static 
+    static
     typename boost::enable_if<typename has_direct_entry<EventType>::type,typename EventType::contained_event const& >::type
     remove_direct_entry_event_wrapper(EventType const& evt,boost::msm::back::dummy<0> = 0)
     {
@@ -2779,7 +2791,7 @@ BOOST_PP_REPEAT(BOOST_PP_ADD(BOOST_MSM_VISITOR_ARG_SIZE,1), MSM_VISITOR_ARGS_EXE
         typename ::boost::enable_if<typename is_pseudo_exit<StateType>::type,void >::type
     execute_entry(StateType& astate,EventType const& evt,FsmType& fsm, ::boost::msm::back::dummy<2> = 0)
     {
-        // calls on_entry on the state then forward the event to the transition which should be defined inside the 
+        // calls on_entry on the state then forward the event to the transition which should be defined inside the
         // contained fsm
         astate.on_entry(evt,fsm);
         astate.forward_event(evt);
@@ -2840,7 +2852,7 @@ BOOST_PP_REPEAT(BOOST_PP_ADD(BOOST_MSM_VISITOR_ARG_SIZE,1), MSM_VISITOR_ARGS_EXE
 
 private:
     template <class StateType,class Enable=void>
-    struct msg_queue_helper 
+    struct msg_queue_helper
     {
     public:
         msg_queue_helper():m_events_queue(){}
@@ -2848,7 +2860,7 @@ private:
     };
     template <class StateType>
     struct msg_queue_helper<StateType,
-        typename ::boost::enable_if<typename is_no_message_queue<StateType>::type >::type> 
+        typename ::boost::enable_if<typename is_no_message_queue<StateType>::type >::type>
     {
     };
 


### PR DESCRIPTION
Currently, MSM dispatches events that have been placed on the deferred queue and message queue via a recursive call mechanism, where enqueued events are processed in the same run-to-completion algorithm as the one that called them.

Whilst this works under the majority of cases, large numbers of events being enqueued cause the stack to be blown when processing from the queue.

The proposed fix for this is within this pull request. The general idea of this fix is:

* Process enqueued events iteratively in a while loop, rather than using recursion.
* Using a 'sequence' identifier within the deferred queue. Each successful handle of an event / transition causes the sequence to be updated. When the sequence associated with an enqueued event is past the current sequence, we yield and allow processing to resume from the calling `process_event_internal()`. This ensures events deferred aren't processed in the same RTC cycle.
* No longer iterate the entire deferred queue to mark events to be handled, due to the new sequence mechanism.
* Only processing the deferred queue and message queue if we aren't currently handling a deferred event. This ensures recursion doesn't take place, but still guarantees event dispatch ordering compatible with the latest version of the UML.
* Change the signature of `process_event_internal` from `Event, bool` to `Event, EventSource`. `EventSource` is a bitset declared in `back/common_types.hpp` which allows us to define if we are processing an event from the message queue, deferred queue, and if we are in a direct call.
* Some small optimisation fixes to reduce the numbers of copies, tidy up line endings etc.

I have re-run the MSM unit tests, and these all still pass successfully:

```
./CompositeMachine.cpp.bin
Running 1 test case...

*** No errors detected
./SimpleEuml2.cpp.bin
Running 1 test case...

*** No errors detected
./Entries.cpp.bin
Running 1 test case...

*** No errors detected
./OrthogonalDeferred2.cpp.bin
Running 1 test case...

*** No errors detected
./OrthogonalDeferred.cpp.bin
Running 1 test case...

*** No errors detected
./SimpleEuml.cpp.bin
Running 1 test case...

*** No errors detected
./SerializeWithHistory.cpp.bin
Running 1 test case...

*** No errors detected
./Serialize.cpp.bin
Running 1 test case...

*** No errors detected
./SerializeSimpleEuml.cpp.bin
Running 1 test case...

*** No errors detected
./AnonymousEuml.cpp.bin
Running 1 test case...

*** No errors detected
./Constructor.cpp.bin
Running 1 test case...

*** No errors detected
./SimpleInternal.cpp.bin
Running 1 test case...

*** No errors detected
./EventQueue.cpp.bin
Running 1 test case...

*** No errors detected
./CompositeEuml.cpp.bin
Running 1 test case...

*** No errors detected
./TestConstructor.cpp.bin
Running 1 test case...

*** No errors detected
./OrthogonalDeferred3.cpp.bin
Running 1 test case...
play 0
is_play: 1
MyDefer
play 1
play 1b
is_play: 0
play 1c
is_play: 1
MyDefer
play 1d
is_play: 0
play 2
play 3

*** No errors detected
./History.cpp.bin
Running 1 test case...

*** No errors detected
./SimpleMachine.cpp.bin
Running 1 test case...

*** No errors detected
./SimpleWithFunctors.cpp.bin
Running 1 test case...

*** No errors detected
./OrthogonalDeferredEuml.cpp.bin
Running 1 test case...

*** No errors detected
./SimpleInternalEuml.cpp.bin
Running 1 test case...

*** No errors detected
./SimpleInternalFunctors.cpp.bin
Running 1 test case...

*** No errors detected
./Anonymous.cpp.bin
Running 1 test case...

*** No errors detected
```

Consideration has been given to ensure the UML is honoured, as well as preservation of existing behaviour, including orthogonal region processing, submachines, and flags.

Any further questions on this, I'd be happy to answer, and / or modify the code to suit.

Best Regards,
Tom