### PR TITLE
Fix unused typedef warning in state_machine.hpp

### DIFF
--- a/include/boost/msm/back/state_machine.hpp
+++ b/include/boost/msm/back/state_machine.hpp
@@ -2156,7 +2156,6 @@ private:
         {
             typedef typename get_flag_list<StateType>::type flags;
             typedef typename ::boost::mpl::contains<flags,Flag >::type found;
-            typedef typename is_composite_state<StateType>::type composite;
 
             BOOST_STATIC_CONSTANT(int, state_id = (get_state_id<stt,StateType>::type::value));
             if (found::type::value)


### PR DESCRIPTION
Hi,

This small patch fixes a local unused typedef warning with gcc. It is blocking for people using -Wall -Wextra -Werror compilation flags.

All releases from boost 1.58 to boost 1.61 are affected. Note that apparently this code has been refactored in the "develop" branch.

Cheers,
Romain
