### PR TITLE
start raises m_event_processing

### DIFF
--- a/include/boost/msm/back/state_machine.hpp
+++ b/include/boost/msm/back/state_machine.hpp
@@ -1216,9 +1216,10 @@ private:
     // start the state machine (calls entry of the initial state)
     void start()
     {
-         // reinitialize our list of currently active states with the ones defined in Derived::initial_state
-         ::boost::mpl::for_each< seq_initial_states, ::boost::msm::wrap<mpl::placeholders::_1> >
+        // reinitialize our list of currently active states with the ones defined in Derived::initial_state
+        ::boost::mpl::for_each< seq_initial_states, ::boost::msm::wrap<mpl::placeholders::_1> >
                         (init_states(m_states));
+        m_event_processing = true;
         // call on_entry on this SM
         (static_cast<Derived*>(this))->on_entry(fsm_initial_event(),*this);
         ::boost::mpl::for_each<initial_states, boost::msm::wrap<mpl::placeholders::_1> >
@@ -1226,6 +1227,7 @@ private:
         // give a chance to handle an anonymous (eventless) transition
         handle_eventless_transitions_helper<library_sm> eventless_helper(this,true);
         eventless_helper.process_completion_event();
+        do_post_msg_queue_helper(::boost::mpl::bool_<is_no_message_queue<library_sm>::type::value>());
     }
 
     // start the state machine (calls entry of the initial state passing incomingEvent to on_entry's)
@@ -1235,6 +1237,7 @@ private:
         // reinitialize our list of currently active states with the ones defined in Derived::initial_state
         ::boost::mpl::for_each< seq_initial_states, ::boost::msm::wrap<mpl::placeholders::_1> >
                         (init_states(m_states));
+        m_event_processing = true;
         // call on_entry on this SM
         (static_cast<Derived*>(this))->on_entry(incomingEvent,*this);
         ::boost::mpl::for_each<initial_states, boost::msm::wrap<mpl::placeholders::_1> >
@@ -1242,6 +1245,7 @@ private:
         // give a chance to handle an anonymous (eventless) transition
         handle_eventless_transitions_helper<library_sm> eventless_helper(this,true);
         eventless_helper.process_completion_event();
+        do_post_msg_queue_helper(::boost::mpl::bool_<is_no_message_queue<library_sm>::type::value>());
     }
 
     // stop the state machine (calls exit of the current state)


### PR DESCRIPTION
Fix for the issue #13132: process_event called upon initial on_entry does not wait for on_entry completion. 