### PR TITLE
C++17 fixes (because of removed std::random_shuffle)

### DIFF
--- a/include/boost/msm/front/euml/transformation.hpp
+++ b/include/boost/msm/front/euml/transformation.hpp
@@ -40,6 +40,9 @@ BOOST_MSM_EUML_FUNCTION(Generate_ , std::generate , generate_ , void , void )
 BOOST_MSM_EUML_FUNCTION(Unique_ , std::unique , unique_ , RESULT_TYPE_PARAM1 , RESULT_TYPE2_PARAM1 )
 BOOST_MSM_EUML_FUNCTION(UniqueCopy_ , std::unique_copy , unique_copy_ , RESULT_TYPE_PARAM3 , RESULT_TYPE2_PARAM3 )
 BOOST_MSM_EUML_FUNCTION(RandomShuffle_ , std::random_shuffle , random_shuffle_ , void , void )
+#if __cplusplus >= 201103L
+BOOST_MSM_EUML_FUNCTION(Shuffle_ , std::shuffle , shuffle_ , void , void )
+#endif
 BOOST_MSM_EUML_FUNCTION(RotateCopy_ , std::rotate_copy , rotate_copy_ , RESULT_TYPE_PARAM4 , RESULT_TYPE2_PARAM4 )
 BOOST_MSM_EUML_FUNCTION(Partition_ , std::partition , partition_ , RESULT_TYPE_PARAM1 , RESULT_TYPE2_PARAM1 )
 BOOST_MSM_EUML_FUNCTION(StablePartition_ , std::stable_partition , stable_partition_ , RESULT_TYPE_PARAM1 , RESULT_TYPE2_PARAM1 )

--- a/include/boost/msm/front/euml/transformation.hpp
+++ b/include/boost/msm/front/euml/transformation.hpp
@@ -39,7 +39,9 @@ BOOST_MSM_EUML_FUNCTION(Fill_ , std::fill , fill_ , void , void )
 BOOST_MSM_EUML_FUNCTION(Generate_ , std::generate , generate_ , void , void )
 BOOST_MSM_EUML_FUNCTION(Unique_ , std::unique , unique_ , RESULT_TYPE_PARAM1 , RESULT_TYPE2_PARAM1 )
 BOOST_MSM_EUML_FUNCTION(UniqueCopy_ , std::unique_copy , unique_copy_ , RESULT_TYPE_PARAM3 , RESULT_TYPE2_PARAM3 )
+#if __cplusplus < 201703L
 BOOST_MSM_EUML_FUNCTION(RandomShuffle_ , std::random_shuffle , random_shuffle_ , void , void )
+#endif
 #if __cplusplus >= 201103L
 BOOST_MSM_EUML_FUNCTION(Shuffle_ , std::shuffle , shuffle_ , void , void )
 #endif


### PR DESCRIPTION
With C++17 `std::random_shuffle` was removed and because of that compilation fails with errors like this:


```
In file included from BoostMsmCompilerStressTest.cpp:24:
In file included from .../boost/msm/front/euml/stl.hpp:15:
In file included from .../boost/msm/front/euml/algorithm.hpp:16:
.../boost/msm/front/euml/transformation.hpp:42:47: error: no member named 'random_shuffle' in namespace 'std'
BOOST_MSM_EUML_FUNCTION(RandomShuffle_ , std::random_shuffle , random_shuffle_ , void , void )
                                         ~~~~~^
.../boost/msm/front/euml/common.hpp:2185:16: note: expanded from macro 'BOOST_MSM_EUML_FUNCTION'
        return function (Param1()(evt,fsm,src,tgt));}                                                   \
               ^~~~~~~~
```

This pull-request fixes it by conditionally removing that action `RandomShuffle_` if compiled with C++17 or later.

Additionally, it conditionally adds a new action `Shuffle_` if compiled with C++11 or later.