### PR TITLE
Fix test, by closing the archive-output-stream before reading archive

### DIFF
--- a/test/Serialize.cpp
+++ b/test/Serialize.cpp
@@ -232,9 +232,9 @@ namespace
         BOOST_CHECK_MESSAGE(p.get_state<player_::Open&>().entry_counter == 1,"Open entry not called correctly");
 
         // test the serialization
-        std::ofstream ofs("fsm.txt");
         // save fsm to archive (current state is Open)
         {
+            std::ofstream ofs("fsm_Serialize.txt");
             boost::archive::text_oarchive oa(ofs);
             // write class instance to archive
             oa << p;
@@ -243,7 +243,7 @@ namespace
         player p2;
         {
             // create and open an archive for input
-            std::ifstream ifs("fsm.txt");
+            std::ifstream ifs("fsm_Serialize.txt");
             boost::archive::text_iarchive ia(ifs);
             // read class state from archive
             ia >> p2;

--- a/test/SerializeSimpleEuml.cpp
+++ b/test/SerializeSimpleEuml.cpp
@@ -134,9 +134,9 @@ namespace
                             "Open entry not called correctly");
 
         // test the serialization
-        std::ofstream ofs("fsm.txt");
         // save fsm to archive (current state is Open)
         {
+            std::ofstream ofs("fsm_serializeSimpleEuml.txt");
             boost::archive::text_oarchive oa(ofs);
             // write class instance to archive
             oa << p2;
@@ -145,7 +145,7 @@ namespace
         player p;
         {
             // create and open an archive for input
-            std::ifstream ifs("fsm.txt");
+            std::ifstream ifs("fsm_serializeSimpleEuml.txt");
             boost::archive::text_iarchive ia(ifs);
             // read class state from archive
             ia >> p;

--- a/test/SerializeWithHistory.cpp
+++ b/test/SerializeWithHistory.cpp
@@ -326,9 +326,9 @@ namespace
         BOOST_CHECK_MESSAGE(p.get_state<player_::Playing&>().exit_counter == 1,"Playing exit not called correctly");
         BOOST_CHECK_MESSAGE(p.get_state<player_::Paused&>().entry_counter == 1,"Paused entry not called correctly");
 
-        std::ofstream ofs("fsm.txt");
         // save fsm to archive (current state is Pause, Playing is in Song2)
         {
+            std::ofstream ofs("fsm_SerializeWithHistory.txt");
             boost::archive::text_oarchive oa(ofs);
             // write class instance to archive
             oa << p;
@@ -337,7 +337,7 @@ namespace
         player p2;
         {
             // create and open an archive for input
-            std::ifstream ifs("fsm.txt");
+            std::ifstream ifs("fsm_SerializeWithHistory.txt");
             boost::archive::text_iarchive ia(ifs);
             // read class state from archive
             ia >> p2;


### PR DESCRIPTION
This fixes the test `my_test` which fails on OSX with the following error-message:
```
Running 1 test case...

unknown location:0: fatal error: in "my_test": boost::archive::archive_exception: array size too short

libs/msm/test/SerializeWithHistory.cpp:327: last checkpoint

*** 1 failure is detected in the test module "MyTest"
```