### PR TITLE
Fix UB for multiple instances of one state machine

### DIFF
--- a/include/boost/msm/back/state_machine.hpp
+++ b/include/boost/msm/back/state_machine.hpp
@@ -2270,10 +2270,12 @@ private:
         BOOST_STATIC_CONSTANT(int, max_state = (mpl::size<state_list>::value));
 
         static flag_handler flags_entries[max_state];
-        // build a state list
-        ::boost::mpl::for_each<state_list, boost::msm::wrap< ::boost::mpl::placeholders::_1> >
-                        (init_flags<Flag>(flags_entries));
-        return flags_entries;
+        // build a state list, but only once
+        static flag_handler* flags_entries_ptr =
+            (::boost::mpl::for_each<state_list, boost::msm::wrap< ::boost::mpl::placeholders::_1> >
+                            (init_flags<Flag>(flags_entries)),
+            flags_entries);
+        return flags_entries_ptr;
     }
 
     // helper used to create a state using the correct constructor


### PR DESCRIPTION
Don't re-initialize flags_entries every time get_entries_for_flag is
called, only once per function template instance.
This fixes a write-write race condition (undefined behavior) when
multiple threads/strands instantiate the same state machine.