### PR TITLE
Remove find_package(boost_serialization)

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,7 +10,6 @@ add_executable(boost_msm_tests
     main.cpp
 )
 target_include_directories(boost_msm_tests PRIVATE ../include)
-find_package(boost_serialization)
 target_link_libraries(boost_msm_tests Boost::serialization)
 target_compile_definitions(boost_msm_tests PRIVATE "BOOST_MSM_NONSTANDALONE_TEST")
 


### PR DESCRIPTION
Not required as this is part of the super-project build which adds this automatically.

This leads to either failures when Boost isn't installed yet or potentially wrong Boost installations found when Building Boost tests

So just remove it.