### PR TITLE
Remove incorrect `template` keyword to fix Clang errors

### DIFF
--- a/test/TestDeferAndMessageQueue.cpp
+++ b/test/TestDeferAndMessageQueue.cpp
@@ -45,7 +45,7 @@ namespace
             template <class EVT,class FSM,class SourceState,class TargetState>
             void operator()(EVT const& ,FSM& fsm,SourceState& ,TargetState& )
             {
-                fsm.template process_event(eventResolve());
+                fsm.process_event(eventResolve());
             }
         };
         struct enqueue_action2
@@ -53,7 +53,7 @@ namespace
             template <class EVT,class FSM,class SourceState,class TargetState>
             void operator()(EVT const& ,FSM& fsm,SourceState& ,TargetState& )
             {
-                fsm.template process_event(eventConnect());
+                fsm.process_event(eventConnect());
             }
         };
         struct expected_action

--- a/test/TestDeferAndMessageQueue2.cpp
+++ b/test/TestDeferAndMessageQueue2.cpp
@@ -73,7 +73,7 @@ namespace
             template <class EVT,class FSM,class SourceState,class TargetState>
             void operator()(EVT const& ,FSM& fsm,SourceState& ,TargetState& )
             {
-                fsm.template process_event(event2());
+                fsm.process_event(event2());
             }
         };
         struct expected_action

--- a/test/TestDeferAndMessageQueue3.cpp
+++ b/test/TestDeferAndMessageQueue3.cpp
@@ -76,7 +76,7 @@ namespace
             template <class EVT,class FSM,class SourceState,class TargetState>
             void operator()(EVT const& ,FSM& fsm,SourceState& ,TargetState& )
             {
-                fsm.template process_event(event2());
+                fsm.process_event(event2());
             }
         };
         struct expected_action


### PR DESCRIPTION
This fixes the CI errors on Clang 19+.

CI still doesn't completely pass, but the remaining failures are unrelated to that.