### PR TITLE
Support UpperFsm via Context template parameter

### DIFF
--- a/include/boost/msm/backmp11/README.md
+++ b/include/boost/msm/backmp11/README.md
@@ -1,6 +1,6 @@
 # Boost MSM backmp11 backend
 
-This README file is temporary and contains information about `backmp11`, a new backend that is mostly backwards-compatible with `back`. It is currently **experimental** stage, thus some details about the compatibility might change.
+This README file is temporary and contains information about `backmp11`, a new backend that is mostly backwards-compatible with `back`. It is currently in **experimental** stage, thus some details about the compatibility might change.
 
 This file's contents should eventually move into the MSM documentation.
 

--- a/include/boost/msm/backmp11/README.md
+++ b/include/boost/msm/backmp11/README.md
@@ -1,13 +1,24 @@
 # Boost MSM backmp11 backend
 
-The new backend `backmp11` is a new backwards-compatible backend that has the following goals:
+This README file is temporary and contains information about `backmp11`, a new backend that is mostly backwards-compatible with `back`. It is currently **experimental** stage, thus some details about the compatibility might change.
+
+This file's contents should eventually move into the MSM documentation.
+
+The new backend has the following goals:
 
 - reduce compilation runtime and RAM usage
 - reduce state machine runtime
 
-It is named after the metaprogramming library Boost Mp11, the main contributor to the optimizations:
-It replaces usages of MPL with Mp11 to get rid of the C++03 emulation of variadic templates.
-This backend contains additional optimizations that are further described below.
+It is named after the metaprogramming library Boost Mp11, the main contributor to the optimizations. Usages of MPL are replaced with Mp11 to get rid of the costly C++03 emulation of variadic templates.
+
+## Breaking changes
+
+- The targeted minimum C++ version is C++17
+- Support for eUML is going to be removed
+
+## New features
+
+The backend supports a `Context` template parameter, that can be used to share common data between sub-SMs in hierarchical state machines.
 
 
 ## How to use it
@@ -20,20 +31,20 @@ When using the `favor_compile_time` policy, a different macro to generate missin
 - use `BOOST_MSM_BACKMP11_GENERATE_DISPATCH_TABLE(<fsmname>)` in place of `BOOST_MSM_BACK_GENERATE_PROCESS_EVENT(<fsmname>)`
 
 
-## General optimizations
+## Applied optimizations
 
-- Replacement of CPU-intensive calls due to C++03 recursion from MPL to Mp11
+- Replacement of CPU-intensive calls (due to C++03 recursion from MPL) with Mp11
 - Applied type punning where useful (to reduce template instantiations, e.g. std::deque & other things around the dispatch table)
 
 
-## Optimizations applied to the `favor_runtime_speed` policy
+### `favor_runtime_speed` policy
 
 Summary:
 - Optimized cell initialization with initializer arrays (to reduce template instantiations)
-- Default-initialized everything and afterwards only defer transition cells
+- Default-initialized everything and afterwards only the defer transition cells
 
 
-## Optimizations applied to the `favor_compile_time` policy
+### `favor_compile_time` policy
 
 Once an event is given to the FSM for processing, it is immediately converted to `any` and processing continues with this `any` event.
 The structure of the dispatch table has been reworked, one dispatch table is created per state as a hash map.
@@ -44,14 +55,13 @@ The new mechanism renders the `process_any_event` function obsolete and enables 
 
 Summary:
 - Use one dispatch table per state to reduce compiler processing time
-  - The algorithms for procesing the STT and states are optimized to go through rows and states only once
+  - The algorithms for processing the STT and states are optimized to go through rows and states only once
   - These dispatch tables are hash tables with type_id as key
-- Apply type erasure with boost::any as early as possible and do further processing only with any events
+- Apply type erasure with `any` as early as possible and do further processing only with any events
   - each dispatch table only has to cover the events it's handling, no template instantiations required for forwarding events to sub-SMs
-- Use `std::any` if C++17 is available (up to 30% runtime impact because of small value optimization in `std::any`)
 
 
-## Learnings:
+### Learnings:
 
 - If only a subset needs to be processed, prefer copy_if & transform over fold
 - Selecting a template-based function overload in Mp11 seems more efficient than using enable_if/disable_if

--- a/include/boost/msm/backmp11/state_machine.hpp
+++ b/include/boost/msm/backmp11/state_machine.hpp
@@ -132,6 +132,7 @@ struct make_euml_terminal<T,F,typename ::boost::enable_if<has_using_declared_tab
 // A0=Derived,A1=NoHistory,A2=CompilePolicy,A3=FsmCheckPolicy >
 template <
       class A0
+    , class Context = void
     , class A1 = parameter::void_
     , class A2 = parameter::void_
     , class A3 = parameter::void_
@@ -141,7 +142,7 @@ class state_machine : //public Derived
     public ::boost::parameter::binding<
             typename state_machine_signature::bind<A0,A1,A2,A3,A4>::type, tag::front_end
     >::type
-    , public make_euml_terminal<state_machine<A0,A1,A2,A3,A4>,
+    , public make_euml_terminal<state_machine<A0,Context,A1,A2,A3,A4>,
                          typename ::boost::parameter::binding<
                                     typename state_machine_signature::bind<A0,A1,A2,A3,A4>::type, tag::front_end
                          >::type
@@ -173,7 +174,7 @@ public:
 private:
 
     typedef state_machine<
-        A0,A1,A2,A3,A4>                             library_sm;
+        A0,Context,A1,A2,A3,A4>                     library_sm;
 
     typedef ::std::function<
         execute_return ()>                          transition_fct;
@@ -195,7 +196,7 @@ private:
     typedef bool (*flag_handler)(library_sm const&);
 
     // all state machines are friend with each other to allow embedding any of them in another fsm
-    template <class ,class , class, class, class
+    template <class, class, class, class, class, class
     > friend class state_machine;
 
     // helper to add, if needed, visitors to all states
@@ -1267,6 +1268,12 @@ private:
         do_exit(finalEvent,*this);
     }
 
+    // Get the context.
+    Context* get_context()
+    {
+        return m_context;
+    }
+
     // Main function used by clients of the derived FSM to make transitions.
     template<class Event>
     execute_return process_event(Event const& evt)
@@ -1672,8 +1679,8 @@ public:
              ::boost::fusion::as_vector(FoldToList()(expr, boost::fusion::nil_())),update_state(this->m_substate_list));
      }
 
-    // Construct with the default initial states
-    state_machine()
+    // Construct with the default initial states and optional context
+    state_machine(Context* context = nullptr)
          :Derived()
          ,m_events_queue()
          ,m_deferred_events_queue()
@@ -1682,6 +1689,7 @@ public:
          ,m_is_included(false)
          ,m_visitors()
          ,m_substate_list()
+         ,m_context(context)
     {
          // initialize our list of states with the ones defined in Derived::initial_state
          ::boost::mpl::for_each< seq_initial_states, ::boost::msm::wrap<mpl::placeholders::_1> >
@@ -2490,7 +2498,9 @@ BOOST_PP_REPEAT(BOOST_PP_ADD(BOOST_MSM_VISITOR_ARG_SIZE,1), MSM_VISITOR_ARGS_EXE
             typename is_composite_state<StateType>::type,void >::type
         new_state_helper(boost::msm::back::dummy<0> = 0) const
         {
-            std::get<get_state_id<stt, StateType>::value>(self->m_substate_list).set_containing_sm(containing_sm);
+            auto& state = std::get<get_state_id<stt, StateType>::value>(self->m_substate_list);
+            state.set_containing_sm(containing_sm);
+            state.m_context = self->m_context;
         }
         // State is a sub fsm without exit pseudo states and does not get a callback to this fsm
         // or state is a normal state and needs nothing except creation
@@ -3003,6 +3013,7 @@ private:
     bool                            m_is_included;
     visitor_fct_helper<BaseState>   m_visitors;
     substate_list                   m_substate_list;
+    Context*                        m_context = nullptr;
 
 
 };

--- a/test/Backmp11UpperFsm.cpp
+++ b/test/Backmp11UpperFsm.cpp
@@ -1,0 +1,113 @@
+// Copyright 2025 Christian Granzin
+// Copyright 2010 Christophe Henry
+// henry UNDERSCORE christophe AT hotmail DOT com
+// This is an extended version of the state machine available in the boost::mpl library
+// Distributed under the same license as the original.
+// Copyright for the original version:
+// Copyright 2005 David Abrahams and Aleksey Gurtovoy. Distributed
+// under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+// back-end
+#include <boost/msm/backmp11/state_machine.hpp>
+//front-end
+#include <boost/msm/front/state_machine_def.hpp>
+#include <boost/msm/front/functor_row.hpp>
+#include <boost/msm/front/euml/common.hpp>
+
+#include <boost/msm/back/queue_container_circular.hpp>
+#include <boost/msm/back/history_policies.hpp>
+
+#ifndef BOOST_MSM_NONSTANDALONE_TEST
+#define BOOST_TEST_MODULE backmp11_upper_fsm_test
+#endif
+#include <boost/test/unit_test.hpp>
+
+namespace msm = boost::msm;
+namespace mp11 = boost::mp11;
+
+using namespace msm::front;
+using namespace msm::backmp11;
+
+namespace
+{
+    // Events.
+    struct EnterSubFsm{};
+    struct ExitSubFsm{};
+
+    // States.
+    struct Default : public state<>{};
+
+    // Forward-declare the backend of the upper machine,
+    // so we can use it as Context.
+    struct UpperMachine;
+    using Context = UpperMachine;
+
+    template<typename T>
+    struct MachineBase_ : public state_machine_def<MachineBase_<T>>
+    {
+        template <typename Event, typename Fsm>
+        void on_entry(const Event& /*event*/, Fsm& fsm)
+        {
+            fsm.get_context()->machine_entries++;
+        };
+
+        template <typename Event, typename Fsm>
+        void on_exit(const Event& /*event*/, Fsm& fsm)
+        {
+            fsm.get_context()->machine_exits++;
+        };
+
+        using initial_state = Default;
+    };
+
+    struct LowerMachine_ : public MachineBase_<LowerMachine_> {};
+    using LowerMachine = state_machine<LowerMachine_, Context>;
+
+    struct MiddleMachine_ : public MachineBase_<MiddleMachine_>
+    {
+        using transition_table = mp11::mp_list<
+            Row< Default      , EnterSubFsm , LowerMachine >,
+            Row< LowerMachine , ExitSubFsm  , Default      >
+        >;
+    };
+    using MiddleMachine = state_machine<MiddleMachine_, Context>;
+
+    struct UpperMachine_ : public MachineBase_<UpperMachine_>
+    {
+        using transition_table = mp11::mp_list<
+            Row< Default       , EnterSubFsm , MiddleMachine>,
+            Row< MiddleMachine , ExitSubFsm  , Default>
+        >;
+
+        uint32_t machine_entries = 0;
+        uint32_t machine_exits = 0;
+    };
+    struct UpperMachine : state_machine<UpperMachine_, Context> {};
+
+
+    BOOST_AUTO_TEST_CASE( backmp11_upper_fsm_test )
+    {
+        UpperMachine test_machine{&test_machine};
+
+        test_machine.start(); 
+        BOOST_CHECK_MESSAGE(test_machine.machine_entries == 1, "SM entry not called correctly");
+
+        test_machine.process_event(EnterSubFsm()); 
+        BOOST_CHECK_MESSAGE(test_machine.machine_entries == 2, "SM entry not called correctly");
+
+        test_machine.process_event(EnterSubFsm()); 
+        BOOST_CHECK_MESSAGE(test_machine.machine_entries == 3, "SM entry not called correctly");
+
+        test_machine.process_event(ExitSubFsm()); 
+        BOOST_CHECK_MESSAGE(test_machine.machine_exits == 1, "SM exit not called correctly");
+
+        test_machine.process_event(ExitSubFsm()); 
+        BOOST_CHECK_MESSAGE(test_machine.machine_exits == 2, "SM exit not called correctly");
+
+        test_machine.stop(); 
+        BOOST_CHECK_MESSAGE(test_machine.machine_exits == 3, "SM exit not called correctly");
+    }
+}
+


### PR DESCRIPTION
Hi @henry-ch 😀 

I looked into how backmp11 can support access to the `UpperFsm` of hierarchical SMs (similar to how you did it in back11) and propose to add a `Context` template parameter. It's very similar to the `UpperFsm` template parameter of back11, but has some benefits which I'll explain further below.

I tried out 3 different approaches for which I have demo MRs in my fork:

### **[Replace the Fsm parameter with the UpperFsm at runtime:](https://github.com/chandryan/msm-ng/pull/9)**

Requires lots of code changes. I managed to get an examplary test case running, but more changes would be required to correctly forward the UpperFsm in all methods.

While from a user perspective this is nice if only access to the UpperFsm is needed, the need to forward the UpperFsm in all related methods has a very big and rather negative impact on the code base. And it seems to completely remove the possibility to access the currently active sub-FSM if needed :(

Considering that a mechanism to *optionally* select the UpperFsm has less impact on the code base and is more universal, I decided to give up on this implementation.


### **[Use a `UpperFsm` template parameter like in back11:](https://github.com/chandryan/msm-ng/pull/8)**

I stumbled upon some issues which already were present in `back11`, that would need to be resolved:

IMO for the sake of simplicity in implementations of actions, the upper fsm should return a pointer to itself when its `get_upper()` API is called. I couldn't find a nice way to "mark" the upper SM without a negative impact on the maintainability of the implementation in MSM:
- Either you mark the upper fsm's template parameter with `void`, which requires additional code to handle the upper fsm itself
- Or you pass the UpperFsm as template parameter, which creates issues due to assigning to a child class when the backend implementation uses inheritance instead of a using directive. Additionally you'd need additional code to implement some kind of post-construction mechanism to make the upper sm store a pointer to itself and then pass itself to its sub-SMs

There is also one location where I needed a reinterpret_cast in the demo MR, of which I'm not sure of the root cause.


### **[Use a `Context` template parameter:](https://github.com/chandryan/msm-ng/pull/7)**

This implementation is very similar to the `UpperFsm` context parameter, though it's more generic:

- It doesn't impose assumptions on what it contains: It *could* be the `UpperFsm`, or it could be some data shared between all FSMs, or it could be both
- Users can pass different instances of this Context at construction time. This makes it a perfect candidate for dependency injection

The API for accessing the context is very similar to the one for accessing the upper fsm in `back11`: `UpperFsm* get_upper()` becomes `Context* get_context()`.

From implementation perspective, it doesn't require custom code for the instantiation of the UpperFsm itself and the semantics are less ambiguous: With `get_upper()` it might not be clear whether the UpperFsm should return a nullptr or a pointer to itself. With a Context mechanism it's clear that all SMs, including the UpperFsm, return a pointer to the context.
