### PR TITLE
Adapt `test/CMakeLists.txt` for standalone vs. super-project builds

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,9 +9,18 @@ add_executable(boost_msm_tests
     ${SOURCES}
     main.cpp
 )
-target_include_directories(boost_msm_tests PRIVATE ../include)
-find_package(boost_serialization)
-target_link_libraries(boost_msm_tests Boost::serialization)
+
+# Build tests standalone
+get_filename_component(PARENT_DIR ${CMAKE_CURRENT_SOURCE_DIR} DIRECTORY)
+if(PARENT_DIR STREQUAL CMAKE_SOURCE_DIR)
+    target_include_directories(boost_msm_tests PRIVATE ../include)
+    find_package(Boost COMPONENTS serialization REQUIRED)
+    target_link_libraries(boost_msm_tests Boost::serialization)
+# Build tests as part of the super-project
+else()    
+    target_link_libraries(boost_msm_tests Boost::msm)
+endif()
+
 target_compile_definitions(boost_msm_tests PRIVATE "BOOST_MSM_NONSTANDALONE_TEST")
 
 add_test(boost_msm_tests boost_msm_tests)


### PR DESCRIPTION
Adapt `test/CMakeLists.txt` as discussed in https://github.com/boostorg/msm/pull/99:

- by linking against `Boost::msm` when built as part of the super-project
- with `find_package` and selective linking when built standalone (might not be required when sticking to build as super-project)