### PR TITLE
Support standalone builds and clean up `test/CMakeLists.txt`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,27 +12,39 @@ add_library(Boost::msm ALIAS boost_msm)
 
 target_include_directories(boost_msm INTERFACE include)
 
-target_link_libraries(boost_msm
-  INTERFACE
-    Boost::any
-    Boost::assert
-    Boost::bind
-    Boost::circular_buffer
-    Boost::config
-    Boost::core
-    Boost::function
-    Boost::fusion
-    Boost::mp11
-    Boost::mpl
-    Boost::parameter
-    Boost::phoenix
-    Boost::preprocessor
-    Boost::proto
-    Boost::serialization
-    Boost::tuple
-    Boost::type_traits
-    Boost::typeof
-)
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    set(BOOST_MSM_IS_ROOT ON)
+else()
+    set(BOOST_MSM_IS_ROOT OFF)
+endif()
+
+if(NOT BOOST_MSM_IS_ROOT)
+  target_link_libraries(boost_msm
+    INTERFACE
+      Boost::any
+      Boost::assert
+      Boost::bind
+      Boost::circular_buffer
+      Boost::config
+      Boost::core
+      Boost::function
+      Boost::fusion
+      Boost::mp11
+      Boost::mpl
+      Boost::parameter
+      Boost::phoenix
+      Boost::preprocessor
+      Boost::proto
+      Boost::serialization
+      Boost::tuple
+      Boost::type_traits
+      Boost::typeof
+  )
+else()
+  # Boost 1.66 is the first version with Mp11
+  find_package(Boost 1.66 REQUIRED COMPONENTS serialization)
+  target_link_libraries(boost_msm INTERFACE Boost::boost Boost::serialization)
+endif()
 
 if(BUILD_TESTING AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/CMakeLists.txt")
   enable_testing()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-file(GLOB SOURCES "*.cpp")
+file(GLOB SOURCES CONFIGURE_DEPENDS "*.cpp")
 if(CMAKE_CXX_STANDARD LESS 20)
     message(STATUS "MSM: CXX standard is below 20, excluding puml tests")
     list(FILTER SOURCES EXCLUDE REGEX "puml|Puml")
@@ -9,18 +9,15 @@ add_executable(boost_msm_tests
     ${SOURCES}
     main.cpp
 )
-
-# Build tests standalone
-get_filename_component(PARENT_DIR ${CMAKE_CURRENT_SOURCE_DIR} DIRECTORY)
-if(PARENT_DIR STREQUAL CMAKE_SOURCE_DIR)
-    target_include_directories(boost_msm_tests PRIVATE ../include)
-    find_package(Boost COMPONENTS serialization REQUIRED)
-    target_link_libraries(boost_msm_tests Boost::serialization)
-# Build tests as part of the super-project
-else()    
-    target_link_libraries(boost_msm_tests Boost::msm)
+if(BOOST_MSM_IS_ROOT)
+    find_package(Boost REQUIRED COMPONENTS unit_test_framework)
 endif()
-
+target_link_libraries(boost_msm_tests Boost::msm Boost::unit_test_framework)
 target_compile_definitions(boost_msm_tests PRIVATE "BOOST_MSM_NONSTANDALONE_TEST")
 
-add_test(boost_msm_tests boost_msm_tests)
+add_test(NAME boost_msm_tests COMMAND boost_msm_tests)
+
+if(NOT TARGET tests)
+    add_custom_target(tests)
+endif()
+add_dependencies(tests boost_msm_tests)


### PR DESCRIPTION
Applied changes:

- Introduced a check whether MSM is built as part of the super-project or standalone in the root CMakeLists.txt
- Removed/fixed the code related to building the tests standalone in the test CMakeLists.txt
- Added the missing dependency to the CMake `tests` target

Resolves https://github.com/boostorg/msm/issues/111