### PR TITLE
Fix link to the documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
 # msm
 Boost.org msm module
-[Please look at the generated documentation](http://htmlpreview.github.com/?https://github.com/boostorg/msm/blob/master/doc/HTML/index.html)
-You might need to force browser reloading (F5)
+[Please look at the generated documentation](https://www.boost.org/doc/libs/master/libs/msm/doc/HTML/index.html)


### PR DESCRIPTION
Fix the link to the documentation in the README.md, refer to boost.org.

Addresses https://github.com/boostorg/msm/issues/92