### PR TITLE
Fix docu link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # msm
 Boost.org msm module
-[Please look at the generated documentation](http://htmlpreview.github.com/?https://github.com/boostorg/msm/blob/master/doc/HTML/index.html)
+[Please look at the generated documentation](http://htmlpreview.github.io/?https://github.com/boostorg/msm/blob/master/doc/HTML/index.html)  
 You might need to force browser reloading (F5)


### PR DESCRIPTION
It seems they change from .com to .io