### PR TITLE
backmp11: Remove eUML and proto dependencies

### DIFF
--- a/include/boost/msm/back11/state_machine.hpp
+++ b/include/boost/msm/back11/state_machine.hpp
@@ -70,10 +70,6 @@
 #include <boost/msm/back/queue_container_deque.hpp>
 #include <boost/msm/back11/dispatch_table.hpp>
 
-#ifndef BOOST_MSM_CONSTRUCTOR_ARG_SIZE
-#define BOOST_MSM_CONSTRUCTOR_ARG_SIZE 5 // default max number of arguments for constructors
-#endif
-
 namespace boost { namespace msm { namespace back11
 {
 // event used internally for wrapping a direct entry

--- a/include/boost/msm/back11/state_machine.hpp
+++ b/include/boost/msm/back11/state_machine.hpp
@@ -70,6 +70,10 @@
 #include <boost/msm/back/queue_container_deque.hpp>
 #include <boost/msm/back11/dispatch_table.hpp>
 
+#ifndef BOOST_MSM_CONSTRUCTOR_ARG_SIZE
+#define BOOST_MSM_CONSTRUCTOR_ARG_SIZE 5 // default max number of arguments for constructors
+#endif
+
 namespace boost { namespace msm { namespace back11
 {
 // event used internally for wrapping a direct entry

--- a/include/boost/msm/backmp11/README.md
+++ b/include/boost/msm/backmp11/README.md
@@ -1,8 +1,6 @@
 # Boost MSM backmp11 backend
 
-This README file is temporary and contains information about `backmp11`, a new backend that is mostly backwards-compatible with `back`. It is currently in **experimental** stage, thus some details about the compatibility might change.
-
-This file's contents should eventually move into the MSM documentation.
+This README file is temporary and contains information about `backmp11`, a new backend that is mostly backwards-compatible with `back`. It is currently in **experimental** stage, thus some details about the compatibility might change (feedback welcome!). This file's contents should eventually move into the MSM documentation.
 
 The new backend has the following goals:
 
@@ -12,11 +10,21 @@ The new backend has the following goals:
 It is named after the metaprogramming library Boost Mp11, the main contributor to the optimizations. Usages of MPL are replaced with Mp11 to get rid of the costly C++03 emulation of variadic templates.
 
 
+## New features
+
+
+## Resolved limitations
+
+### Forwarding constructor arguments to the frontend 
+
+The number of max. constructor arguments is not limited anymore to 'BOOST_MSM_CONSTRUCTOR_ARG_SIZE' and references can be passed directly, there is no need to wrap them with 'boost::ref'.
+
+
 ## Breaking changes
 
 ### The targeted minimum C++ version is C++17
 
-For the sake of compiler features such as `if constexpr`.
+C++11 brings the strongly needed variadic template support for MSM, but later C++ versions provide other important features - for example C++17's `if constexpr`.
 
 
 ### The eUML frontend is not supported
@@ -24,11 +32,12 @@ For the sake of compiler features such as `if constexpr`.
 The support of EUML induces longer compilation times by the need to include the Boost proto headers and applying C++03 variadic template emulation. If you want to use a UML-like syntax, please try out the new PUML frontend.
 
 
-### A state machine's frontend must be default-constructible
+### The backend's constructor does not allow initialization of states and `set_states` is not available
 
-TODO:
-- Double-check that removal is not an issue, check available alternatives post-construction time
-- Provide rationale (proto headers, limitations for hierarchical state machines(?))
+There were some caveats with one constructor that was used for different use cases: On the one hand some arguments were immediately forwarded to the frontend's constructor, on the other hand the stream operator was used to identify other arguments in the constructor as states, to copy them into the state machine. Besides the syntax of the later being rather unusual, when doing both at once the syntax becomes too difficult to understand; even more so if states within hierarchical sub state machines were initialized in this fashion.
+
+In order to keep API of the constructor simpler and less ambiguous, it only supports forwarding arguments to the frontend and no more.
+Also the `set_states` API is removed. If setting a state is required, this can still be done (in a little more verbose, but also more direct & explicit fashion) by getting a reference to the desired state via `get_state` and then assigning the desired new state to it.
 
 
 ## How to use it

--- a/include/boost/msm/backmp11/README.md
+++ b/include/boost/msm/backmp11/README.md
@@ -24,6 +24,13 @@ For the sake of compiler features such as `if constexpr`.
 The support of EUML induces longer compilation times by the need to include the Boost proto headers and applying C++03 variadic template emulation. If you want to use a UML-like syntax, please try out the new PUML frontend.
 
 
+### A state machine's frontend must be default-constructible
+
+TODO:
+- Double-check that removal is not an issue, check available alternatives post-construction time
+- Provide rationale (proto headers, limitations for hierarchical state machines(?))
+
+
 ## How to use it
 
 The backend and both its policies `favor_runtime_speed` and `favor_compile_time` should be compatible with existing code. Required replacements to try it out:

--- a/include/boost/msm/backmp11/README.md
+++ b/include/boost/msm/backmp11/README.md
@@ -1,13 +1,27 @@
 # Boost MSM backmp11 backend
 
-The new backend `backmp11` is a new backwards-compatible backend that has the following goals:
+This README file is temporary and contains information about `backmp11`, a new backend that is mostly backwards-compatible with `back`. It is currently in **experimental** stage, thus some details about the compatibility might change.
+
+This file's contents should eventually move into the MSM documentation.
+
+The new backend has the following goals:
 
 - reduce compilation runtime and RAM usage
 - reduce state machine runtime
 
-It is named after the metaprogramming library Boost Mp11, the main contributor to the optimizations:
-It replaces usages of MPL with Mp11 to get rid of the C++03 emulation of variadic templates.
-This backend contains additional optimizations that are further described below.
+It is named after the metaprogramming library Boost Mp11, the main contributor to the optimizations. Usages of MPL are replaced with Mp11 to get rid of the costly C++03 emulation of variadic templates.
+
+
+## Breaking changes
+
+### The targeted minimum C++ version is C++17
+
+For the sake of compiler features such as `if constexpr`.
+
+
+### The eUML frontend is not supported
+
+The support of EUML induces longer compilation times by the need to include the Boost proto headers and applying C++03 variadic template emulation. If you want to use a UML-like syntax, please try out the new PUML frontend.
 
 
 ## How to use it
@@ -20,20 +34,20 @@ When using the `favor_compile_time` policy, a different macro to generate missin
 - use `BOOST_MSM_BACKMP11_GENERATE_DISPATCH_TABLE(<fsmname>)` in place of `BOOST_MSM_BACK_GENERATE_PROCESS_EVENT(<fsmname>)`
 
 
-## General optimizations
+## Applied optimizations
 
-- Replacement of CPU-intensive calls due to C++03 recursion from MPL to Mp11
+- Replacement of CPU-intensive calls (due to C++03 recursion from MPL) with Mp11
 - Applied type punning where useful (to reduce template instantiations, e.g. std::deque & other things around the dispatch table)
 
 
-## Optimizations applied to the `favor_runtime_speed` policy
+### `favor_runtime_speed` policy
 
 Summary:
 - Optimized cell initialization with initializer arrays (to reduce template instantiations)
-- Default-initialized everything and afterwards only defer transition cells
+- Default-initialized everything and afterwards only the defer transition cells
 
 
-## Optimizations applied to the `favor_compile_time` policy
+### `favor_compile_time` policy
 
 Once an event is given to the FSM for processing, it is immediately converted to `any` and processing continues with this `any` event.
 The structure of the dispatch table has been reworked, one dispatch table is created per state as a hash map.
@@ -44,14 +58,13 @@ The new mechanism renders the `process_any_event` function obsolete and enables 
 
 Summary:
 - Use one dispatch table per state to reduce compiler processing time
-  - The algorithms for procesing the STT and states are optimized to go through rows and states only once
+  - The algorithms for processing the STT and states are optimized to go through rows and states only once
   - These dispatch tables are hash tables with type_id as key
-- Apply type erasure with boost::any as early as possible and do further processing only with any events
+- Apply type erasure with `any` as early as possible and do further processing only with any events
   - each dispatch table only has to cover the events it's handling, no template instantiations required for forwarding events to sub-SMs
-- Use `std::any` if C++17 is available (up to 30% runtime impact because of small value optimization in `std::any`)
 
 
-## Learnings:
+### Learnings:
 
 - If only a subset needs to be processed, prefer copy_if & transform over fold
 - Selecting a template-based function overload in Mp11 seems more efficient than using enable_if/disable_if

--- a/include/boost/msm/backmp11/state_machine.hpp
+++ b/include/boost/msm/backmp11/state_machine.hpp
@@ -58,7 +58,6 @@
 #include <boost/msm/active_state_switching_policies.hpp>
 #include <boost/msm/row_tags.hpp>
 #include <boost/msm/back/traits.hpp>
-#include <boost/msm/back/fold_to_list.hpp>
 #include <boost/msm/backmp11/favor_compile_time.hpp>
 #include <boost/msm/backmp11/metafunctions.hpp>
 #include <boost/msm/backmp11/history_policies.hpp>
@@ -77,7 +76,6 @@ namespace boost { namespace msm { namespace backmp11
 
 using back::no_fsm_check;
 using back::queue_container_deque;
-using back::FoldToList;
 
 
 // event used internally for wrapping a direct entry
@@ -1637,23 +1635,8 @@ public:
          int* const m_initial_states;
          int m_index;
      };
+
  public:
-     struct update_state
-     {
-         update_state(substate_list& to_overwrite_):to_overwrite(&to_overwrite_){}
-         template<typename StateType>
-         void operator()(StateType const& astate) const
-         {
-             std::get<get_state_id<stt, StateType>::value>(*to_overwrite)=astate;
-         }
-         substate_list* to_overwrite;
-     };
-     template <class Expr>
-     void set_states(Expr const& expr)
-     {
-         ::boost::fusion::for_each(
-             ::boost::fusion::as_vector(FoldToList()(expr, boost::fusion::nil_())),update_state(this->m_substate_list));
-     }
 
     // Construct with the default initial states
     state_machine()

--- a/include/boost/msm/backmp11/state_machine.hpp
+++ b/include/boost/msm/backmp11/state_machine.hpp
@@ -1638,24 +1638,25 @@ public:
 
  public:
 
-    // Construct with the default initial states
-    state_machine()
-         :Derived()
-         ,m_events_queue()
-         ,m_deferred_events_queue()
-         ,m_history()
-         ,m_event_processing(false)
-         ,m_is_included(false)
-         ,m_visitors()
-         ,m_substate_list()
-    {
+    // Construct with the default initial states and forward constructor arguments to the frontend.
+    template <typename... Args>
+    state_machine(Args&&... args)
+    : Derived(std::forward<Args>(args)...)
+      ,m_events_queue()
+      ,m_deferred_events_queue()
+      ,m_history()
+      ,m_event_processing(false)
+      ,m_is_included(false)
+      ,m_visitors()
+      ,m_substate_list()
+     {
          // initialize our list of states with the ones defined in Derived::initial_state
          ::boost::mpl::for_each< seq_initial_states, ::boost::msm::wrap<mpl::placeholders::_1> >
                         (init_states(m_states));
          m_history.set_initial_states(m_states);
          // create states
          fill_states(this);
-    }
+     }
 
      // assignment operator using the copy policy to decide if non_copyable, shallow or deep copying is necessary
      library_sm& operator= (library_sm const& rhs)

--- a/test/AnonymousEuml.cpp
+++ b/test/AnonymousEuml.cpp
@@ -9,6 +9,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 // back-end
+#define BOOST_MSM_TEST_EUML
 #include "BackCommon.hpp"
 #include <boost/msm/front/euml/euml.hpp>
 
@@ -163,6 +164,3 @@ namespace
 
     }
 }
-
-using backmp11_fsm = boost::msm::backmp11::state_machine<my_machine_, boost::msm::backmp11::favor_compile_time>;
-BOOST_MSM_BACKMP11_GENERATE_DISPATCH_TABLE(backmp11_fsm);

--- a/test/AnonymousEuml.cpp
+++ b/test/AnonymousEuml.cpp
@@ -9,7 +9,8 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 // back-end
-#define BOOST_MSM_TEST_EUML
+// EUML is not supported by backmp11
+#define BOOST_MSM_TEST_SKIP_BACKMP11
 #include "BackCommon.hpp"
 #include <boost/msm/front/euml/euml.hpp>
 

--- a/test/BackCommon.hpp
+++ b/test/BackCommon.hpp
@@ -19,8 +19,11 @@ template<typename Front>
 using get_test_machines = boost::mpl::vector<
     boost::msm::back::state_machine<Front>,
     boost::msm::back::state_machine<Front, boost::msm::back::favor_compile_time>,
+// EUML is not supported by backmp11.
+#ifndef BOOST_MSM_TEST_EUML
     boost::msm::backmp11::state_machine<Front>,
     boost::msm::backmp11::state_machine<Front, boost::msm::backmp11::favor_compile_time>,
+#endif // BOOST_MSM_TEST_EUML
     boost::msm::back11::state_machine<Front>
     >;
 
@@ -28,8 +31,11 @@ template <template <template <typename...> class, typename = void> class hierarc
 using get_hierarchical_test_machines = boost::mpl::vector<
     hierarchical<boost::msm::back::state_machine>,
     hierarchical<boost::msm::back::state_machine, boost::msm::back::favor_compile_time>,
+// EUML is not supported by backmp11.
+#ifndef BOOST_MSM_TEST_EUML
     hierarchical<boost::msm::backmp11::state_machine>,
     hierarchical<boost::msm::backmp11::state_machine, boost::msm::backmp11::favor_compile_time>,
+#endif // BOOST_MSM_TEST_EUML
     hierarchical<boost::msm::back11::state_machine>
 >;
 

--- a/test/BackCommon.hpp
+++ b/test/BackCommon.hpp
@@ -19,23 +19,21 @@ template<typename Front>
 using get_test_machines = boost::mpl::vector<
     boost::msm::back::state_machine<Front>,
     boost::msm::back::state_machine<Front, boost::msm::back::favor_compile_time>,
-// EUML is not supported by backmp11.
-#ifndef BOOST_MSM_TEST_EUML
+#if !defined(BOOST_MSM_TEST_SKIP_BACKMP11)
     boost::msm::backmp11::state_machine<Front>,
     boost::msm::backmp11::state_machine<Front, boost::msm::backmp11::favor_compile_time>,
-#endif // BOOST_MSM_TEST_EUML
+#endif // BOOST_MSM_TEST_SKIP_BACKMP11
     boost::msm::back11::state_machine<Front>
     >;
 
 template <template <template <typename...> class, typename = void> class hierarchical>
 using get_hierarchical_test_machines = boost::mpl::vector<
-    hierarchical<boost::msm::back::state_machine>,
+hierarchical<boost::msm::back::state_machine>,
     hierarchical<boost::msm::back::state_machine, boost::msm::back::favor_compile_time>,
-// EUML is not supported by backmp11.
-#ifndef BOOST_MSM_TEST_EUML
+#if !defined(BOOST_MSM_TEST_SKIP_BACKMP11)
     hierarchical<boost::msm::backmp11::state_machine>,
     hierarchical<boost::msm::backmp11::state_machine, boost::msm::backmp11::favor_compile_time>,
-#endif // BOOST_MSM_TEST_EUML
+#endif // BOOST_MSM_TEST_SKIP_BACKMP11
     hierarchical<boost::msm::back11::state_machine>
 >;
 

--- a/test/BackCommon.hpp
+++ b/test/BackCommon.hpp
@@ -28,7 +28,7 @@ using get_test_machines = boost::mpl::vector<
 
 template <template <template <typename...> class, typename = void> class hierarchical>
 using get_hierarchical_test_machines = boost::mpl::vector<
-hierarchical<boost::msm::back::state_machine>,
+    hierarchical<boost::msm::back::state_machine>,
     hierarchical<boost::msm::back::state_machine, boost::msm::back::favor_compile_time>,
 #if !defined(BOOST_MSM_TEST_SKIP_BACKMP11)
     hierarchical<boost::msm::backmp11::state_machine>,

--- a/test/CompositeEuml.cpp
+++ b/test/CompositeEuml.cpp
@@ -8,6 +8,7 @@
 // file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
+#define BOOST_MSM_TEST_EUML
 #include "BackCommon.hpp"
 #include <boost/msm/front/euml/euml.hpp>
 
@@ -289,8 +290,3 @@ namespace
 using back0 = hierarchical_state_machine<boost::msm::back::state_machine, boost::msm::back::favor_compile_time>::player;
 using back1 = hierarchical_state_machine<boost::msm::back::state_machine, boost::msm::back::favor_compile_time>::Playing_type;
 BOOST_MSM_BACK_GENERATE_PROCESS_EVENT(back1);
-
-using backmp11_0 = hierarchical_state_machine<boost::msm::backmp11::state_machine, boost::msm::backmp11::favor_compile_time>::player;
-BOOST_MSM_BACKMP11_GENERATE_DISPATCH_TABLE(backmp11_0);
-using backmp11_1 = hierarchical_state_machine<boost::msm::backmp11::state_machine, boost::msm::backmp11::favor_compile_time>::Playing_type;
-BOOST_MSM_BACKMP11_GENERATE_DISPATCH_TABLE(backmp11_1);

--- a/test/CompositeEuml.cpp
+++ b/test/CompositeEuml.cpp
@@ -8,7 +8,8 @@
 // file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-#define BOOST_MSM_TEST_EUML
+// EUML is not supported by backmp11
+#define BOOST_MSM_TEST_SKIP_BACKMP11
 #include "BackCommon.hpp"
 #include <boost/msm/front/euml/euml.hpp>
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -35,6 +35,7 @@ test-suite msm-unit-tests
     [ run AnonymousAndGuard.cpp ]
     [ run AnonymousEuml.cpp ]
     [ run Back11CompositeMachine.cpp ]
+    [ run Backmp11TestConstructor.cpp ]
     [ run BigWithFunctors.cpp ]
     [ run CompositeEuml.cpp ]
     [ run CompositeMachine.cpp ]

--- a/test/OrthogonalDeferredEuml.cpp
+++ b/test/OrthogonalDeferredEuml.cpp
@@ -155,9 +155,7 @@ namespace
     // Pick a back-end
     typedef boost::mpl::vector<
         hierarchical_state_machine<boost::msm::back::state_machine>,
-        hierarchical_state_machine<boost::msm::back::state_machine, boost::msm::back::favor_compile_time>,
-        hierarchical_state_machine<boost::msm::backmp11::state_machine>,
-        hierarchical_state_machine<boost::msm::backmp11::state_machine, boost::msm::backmp11::favor_compile_time>
+        hierarchical_state_machine<boost::msm::back::state_machine, boost::msm::back::favor_compile_time>
         // TODO:
         // Investigate reason for test failure in back11.
         // hierarchical_state_machine<boost::msm::back11::state_machine>
@@ -375,8 +373,3 @@ namespace
 using back0 = hierarchical_state_machine<boost::msm::back::state_machine, boost::msm::back::favor_compile_time>::player;
 using back1 = hierarchical_state_machine<boost::msm::back::state_machine, boost::msm::back::favor_compile_time>::Playing_type;
 BOOST_MSM_BACK_GENERATE_PROCESS_EVENT(back1);
-
-using backmp11_0 = hierarchical_state_machine<boost::msm::backmp11::state_machine, boost::msm::backmp11::favor_compile_time>::player;
-BOOST_MSM_BACKMP11_GENERATE_DISPATCH_TABLE(backmp11_0);
-using backmp11_1 = hierarchical_state_machine<boost::msm::backmp11::state_machine, boost::msm::backmp11::favor_compile_time>::Playing_type;
-BOOST_MSM_BACKMP11_GENERATE_DISPATCH_TABLE(backmp11_1);

--- a/test/SerializeSimpleEuml.cpp
+++ b/test/SerializeSimpleEuml.cpp
@@ -8,6 +8,7 @@
 // file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
+#define BOOST_MSM_TEST_EUML
 #include "BackCommon.hpp"
 #include <boost/msm/front/euml/euml.hpp>
 
@@ -213,6 +214,3 @@ namespace
 // at the risk of a programming error creating duplicate objects.
 // this is to get rid of warning because p is not const
 // BOOST_CLASS_TRACKING(player, boost::serialization::track_never)
-
-using backmp11_fsm = boost::msm::backmp11::state_machine<player_, boost::msm::backmp11::favor_compile_time>;
-BOOST_MSM_BACKMP11_GENERATE_DISPATCH_TABLE(backmp11_fsm);

--- a/test/SerializeSimpleEuml.cpp
+++ b/test/SerializeSimpleEuml.cpp
@@ -8,7 +8,8 @@
 // file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-#define BOOST_MSM_TEST_EUML
+// EUML is not supported by backmp11
+#define BOOST_MSM_TEST_SKIP_BACKMP11
 #include "BackCommon.hpp"
 #include <boost/msm/front/euml/euml.hpp>
 

--- a/test/SetStates.cpp
+++ b/test/SetStates.cpp
@@ -9,6 +9,8 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 // back-end
+// set_states API is not supported by backmp11
+#define BOOST_MSM_TEST_SKIP_BACKMP11
 #include "BackCommon.hpp"
 //front-end
 #include <boost/msm/front/state_machine_def.hpp>

--- a/test/SimpleEuml.cpp
+++ b/test/SimpleEuml.cpp
@@ -8,6 +8,7 @@
 // file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
+#define BOOST_MSM_TEST_EUML
 #include "BackCommon.hpp"
 #include <boost/msm/front/euml/euml.hpp>
 
@@ -193,6 +194,3 @@ namespace
                             "Stopped entry not called correctly");
     }
 }
-
-using backmp11_fsm = boost::msm::backmp11::state_machine<player_, boost::msm::backmp11::favor_compile_time>;
-BOOST_MSM_BACKMP11_GENERATE_DISPATCH_TABLE(backmp11_fsm);

--- a/test/SimpleEuml.cpp
+++ b/test/SimpleEuml.cpp
@@ -8,7 +8,8 @@
 // file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-#define BOOST_MSM_TEST_EUML
+// EUML is not supported by backmp11
+#define BOOST_MSM_TEST_SKIP_BACKMP11
 #include "BackCommon.hpp"
 #include <boost/msm/front/euml/euml.hpp>
 

--- a/test/SimpleEuml2.cpp
+++ b/test/SimpleEuml2.cpp
@@ -8,6 +8,7 @@
 // file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
+#define BOOST_MSM_TEST_EUML
 #include "BackCommon.hpp"
 #include <boost/msm/front/euml/euml.hpp>
 
@@ -193,6 +194,3 @@ namespace
                             "Stopped entry not called correctly");
     }
 }
-
-using backmp11_fsm = boost::msm::backmp11::state_machine<player_, boost::msm::backmp11::favor_compile_time>;
-BOOST_MSM_BACKMP11_GENERATE_DISPATCH_TABLE(backmp11_fsm);

--- a/test/SimpleEuml2.cpp
+++ b/test/SimpleEuml2.cpp
@@ -8,7 +8,8 @@
 // file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-#define BOOST_MSM_TEST_EUML
+// EUML is not supported by backmp11
+#define BOOST_MSM_TEST_SKIP_BACKMP11
 #include "BackCommon.hpp"
 #include <boost/msm/front/euml/euml.hpp>
 

--- a/test/SimpleInternalEuml.cpp
+++ b/test/SimpleInternalEuml.cpp
@@ -8,7 +8,8 @@
 // file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-#define BOOST_MSM_TEST_EUML
+// EUML is not supported by backmp11
+#define BOOST_MSM_TEST_SKIP_BACKMP11
 #include "BackCommon.hpp"
 #include <boost/msm/front/euml/euml.hpp>
 #ifndef BOOST_MSM_NONSTANDALONE_TEST

--- a/test/SimpleInternalEuml.cpp
+++ b/test/SimpleInternalEuml.cpp
@@ -8,6 +8,7 @@
 // file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
+#define BOOST_MSM_TEST_EUML
 #include "BackCommon.hpp"
 #include <boost/msm/front/euml/euml.hpp>
 #ifndef BOOST_MSM_NONSTANDALONE_TEST
@@ -251,6 +252,3 @@ namespace
                             "Stopped entry not called correctly");
     }
 }
-
-using backmp11_fsm = boost::msm::backmp11::state_machine<player_, boost::msm::backmp11::favor_compile_time>;
-BOOST_MSM_BACKMP11_GENERATE_DISPATCH_TABLE(backmp11_fsm);


### PR DESCRIPTION
Applied changes for backmp11:
Removed suppport for eUML and other proto dependencies (https://github.com/boostorg/msm/issues/106), which includes the `set_states` API as well as copying states into the SM in the backend constructor. 
Added a rationale for the removal of them in the temp README under the backmp11 include dir.
Added a Backmp11 version of TestConstructor.cpp to test the adapted constructor and to make sure states can still be copied by using `get_state`.

The removal leads to about ~0.5s less compile time and ~20MB less RAM usage.

This PR also removes some of the test failures mentioned in https://github.com/boostorg/msm/issues/105