### PR TITLE
backmp11: Rework the visitor implementation

### DIFF
--- a/include/boost/msm/backmp11/README.md
+++ b/include/boost/msm/backmp11/README.md
@@ -1,13 +1,23 @@
 # Boost MSM backmp11 backend
 
-The new backend `backmp11` is a new backwards-compatible backend that has the following goals:
+This README file is temporary and contains information about `backmp11`, a new backend that is mostly backwards-compatible with `back`. It is currently in **experimental** stage, thus some details about the compatibility might change (feedback welcome!). This file's contents should eventually move into the MSM documentation.
+
+The new backend has the following goals:
 
 - reduce compilation runtime and RAM usage
 - reduce state machine runtime
 
-It is named after the metaprogramming library Boost Mp11, the main contributor to the optimizations:
-It replaces usages of MPL with Mp11 to get rid of the C++03 emulation of variadic templates.
-This backend contains additional optimizations that are further described below.
+It is named after the metaprogramming library Boost Mp11, the main contributor to the optimizations. Usages of MPL are replaced with Mp11 to get rid of the costly C++03 emulation of variadic templates.
+
+## Behavioral changes
+
+### Visitor API
+
+- The argument size limitation `BOOST_MSM_VISITOR_ARG_SIZE` has been removed, the new visitor implementation uses perfect forwarding.
+- There is no need to declare an `accept_sig` in the base state, it is automatically derived from the signature of its `accept` method.
+- As long as the state machine is not running (before start resp. after stop), no states will be visited. The previous behavior was errorneous in the following way:
+    - If the SM was not started yet, the initial state(s) were visited
+    - If the SM was stopped, the last active state(s) were visited
 
 
 ## How to use it
@@ -20,20 +30,20 @@ When using the `favor_compile_time` policy, a different macro to generate missin
 - use `BOOST_MSM_BACKMP11_GENERATE_DISPATCH_TABLE(<fsmname>)` in place of `BOOST_MSM_BACK_GENERATE_PROCESS_EVENT(<fsmname>)`
 
 
-## General optimizations
+## Applied optimizations
 
-- Replacement of CPU-intensive calls due to C++03 recursion from MPL to Mp11
+- Replacement of CPU-intensive calls (due to C++03 recursion from MPL) with Mp11
 - Applied type punning where useful (to reduce template instantiations, e.g. std::deque & other things around the dispatch table)
 
 
-## Optimizations applied to the `favor_runtime_speed` policy
+### `favor_runtime_speed` policy
 
 Summary:
 - Optimized cell initialization with initializer arrays (to reduce template instantiations)
-- Default-initialized everything and afterwards only defer transition cells
+- Default-initialized everything and afterwards only the defer transition cells
 
 
-## Optimizations applied to the `favor_compile_time` policy
+### `favor_compile_time` policy
 
 Once an event is given to the FSM for processing, it is immediately converted to `any` and processing continues with this `any` event.
 The structure of the dispatch table has been reworked, one dispatch table is created per state as a hash map.
@@ -44,14 +54,13 @@ The new mechanism renders the `process_any_event` function obsolete and enables 
 
 Summary:
 - Use one dispatch table per state to reduce compiler processing time
-  - The algorithms for procesing the STT and states are optimized to go through rows and states only once
+  - The algorithms for processing the STT and states are optimized to go through rows and states only once
   - These dispatch tables are hash tables with type_id as key
-- Apply type erasure with boost::any as early as possible and do further processing only with any events
+- Apply type erasure with `any` as early as possible and do further processing only with any events
   - each dispatch table only has to cover the events it's handling, no template instantiations required for forwarding events to sub-SMs
-- Use `std::any` if C++17 is available (up to 30% runtime impact because of small value optimization in `std::any`)
 
 
-## Learnings:
+### Learnings:
 
 - If only a subset needs to be processed, prefer copy_if & transform over fold
 - Selecting a template-based function overload in Mp11 seems more efficient than using enable_if/disable_if

--- a/include/boost/msm/backmp11/metafunctions.hpp
+++ b/include/boost/msm/backmp11/metafunctions.hpp
@@ -66,6 +66,23 @@ namespace boost { namespace msm { namespace backmp11
 
 using back::favor_runtime_speed;
 
+// check whether a state has an accept method
+template<typename State, typename = void>
+struct has_accept_method : std::false_type {};
+template<typename State>
+struct has_accept_method<State, decltype(void(&State::accept))> : std::true_type {};
+
+// get the signature of a member function as list
+template <typename T>
+struct member_function_signature;
+template <typename Class, typename Ret, typename... Args>
+struct member_function_signature<Ret (Class::*)(Args...)>
+{
+    using type = mp11::mp_list<Ret, Args...>;
+};
+template<typename T>
+using member_function_signature_t = typename member_function_signature<T>::type;
+
 template <typename Sequence, typename Range>
 struct set_insert_range
 {
@@ -899,8 +916,8 @@ is_exit_state_active(FSM& fsm)
     typedef typename Composite::stt stt;
     int state_id = get_state_id<stt,StateType>::type::value;
     Composite& comp = fsm.template get_state<Composite&>();
-    return (std::find(comp.current_state(),comp.current_state()+Composite::nr_regions::value,state_id)
-                            !=comp.current_state()+Composite::nr_regions::value);
+    return (std::find(comp.current_state(),comp.current_state()+Composite::nr_regions,state_id)
+                            !=comp.current_state()+Composite::nr_regions);
 }
 template <class StateType,class OwnerFct,class FSM>
 inline

--- a/test/Backmp11Visitor.cpp
+++ b/test/Backmp11Visitor.cpp
@@ -1,0 +1,145 @@
+// Copyright 2025 Christian Granzin
+// Copyright 2010 Christophe Henry
+// henry UNDERSCORE christophe AT hotmail DOT com
+// This is an extended version of the state machine available in the boost::mpl library
+// Distributed under the same license as the original.
+// Copyright for the original version:
+// Copyright 2005 David Abrahams and Aleksey Gurtovoy. Distributed
+// under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+// back-end
+#include <boost/msm/backmp11/state_machine.hpp>
+//front-end
+#include <boost/msm/front/state_machine_def.hpp>
+#include <boost/msm/front/functor_row.hpp>
+
+#ifndef BOOST_MSM_NONSTANDALONE_TEST
+#define BOOST_TEST_MODULE backmp11_visitor_test
+#endif
+#include <boost/test/unit_test.hpp>
+
+namespace msm = boost::msm;
+namespace mp11 = boost::mp11;
+
+using namespace msm::front;
+using namespace msm::backmp11;
+
+namespace
+{
+    struct StateBase
+    {
+        size_t visits;
+    };
+
+    class Visitor
+    {
+      public:
+        virtual void visit(StateBase& state, int& visits) = 0;
+    };
+
+    struct CountVisitor : public Visitor
+    {
+        void visit(StateBase& state, int& visits) override
+        {
+            visits += 1;
+            state.visits += 1;
+        }
+    };
+
+    struct ResetCountVisitor : public Visitor
+    {
+        void visit(StateBase& state, int& visits) override
+        {
+            visits = 0;
+            state.visits = 0;
+        }
+    };
+
+    // base state for all states of the fsm, to make them visitable
+    struct VisitableState : StateBase
+    {
+        // implementation of the accept function
+        void accept(Visitor& vis, int& i)
+        {
+            vis.visit(*this, i);
+        }
+    };
+
+    // Events.
+    struct EnterSubFsm{};
+    struct ExitSubFsm{};
+
+    // States.
+    struct DefaultState : public state<VisitableState>{ };
+
+    template<typename T>
+    struct MachineBase_ : public state_machine_def<MachineBase_<T>, VisitableState>
+    {
+        using initial_state = DefaultState;
+    };
+
+    struct LowerMachine_ : public MachineBase_<LowerMachine_> { };
+    using LowerMachine = state_machine<LowerMachine_>;
+
+    struct MiddleMachine_ : public MachineBase_<MiddleMachine_>
+    {
+        using transition_table = mp11::mp_list<
+            Row< DefaultState , EnterSubFsm , LowerMachine >,
+            Row< LowerMachine , ExitSubFsm  , DefaultState >
+        >;
+    };
+    using MiddleMachine = state_machine<MiddleMachine_>;
+
+    struct UpperMachine_ : public MachineBase_<UpperMachine_>
+    {
+        using transition_table = mp11::mp_list<
+            Row< DefaultState  , EnterSubFsm , MiddleMachine>,
+            Row< MiddleMachine , ExitSubFsm  , DefaultState>
+        >;
+    };
+    using UpperMachine = state_machine<UpperMachine_>;
+    
+    BOOST_AUTO_TEST_CASE( backmp11_upper_fsm_test )
+    {
+        UpperMachine upper_machine{};
+        CountVisitor count_visitor;
+        ResetCountVisitor reset_count_visitor;
+        int visits = 0;
+        auto& upper_machine_state = upper_machine.get_state<DefaultState&>();
+        auto& middle_machine = upper_machine.get_state<MiddleMachine&>();
+        auto& middle_machine_state = middle_machine.get_state<DefaultState&>();
+        auto& lower_machine = middle_machine.get_state<LowerMachine&>();
+        auto& lower_machine_state = lower_machine.get_state<DefaultState&>();
+
+        upper_machine.visit_current_states(count_visitor, visits);
+        BOOST_REQUIRE(visits == 0);
+        
+        upper_machine.start();
+        upper_machine.visit_current_states(count_visitor, visits);
+        BOOST_REQUIRE(upper_machine_state.visits == 1);
+        BOOST_REQUIRE(visits == 1);
+        upper_machine.visit_current_states(reset_count_visitor, visits);
+
+        upper_machine.process_event(EnterSubFsm());
+        upper_machine.visit_current_states(count_visitor, visits);
+        BOOST_REQUIRE(middle_machine.visits == 1);
+        BOOST_REQUIRE(middle_machine_state.visits == 1);
+        BOOST_REQUIRE(visits == 2);
+        upper_machine.visit_current_states(reset_count_visitor, visits);
+
+        upper_machine.process_event(EnterSubFsm());
+        upper_machine.visit_current_states(count_visitor, visits);
+        BOOST_REQUIRE(middle_machine.visits == 1);
+        BOOST_REQUIRE(lower_machine.visits == 1);
+        BOOST_REQUIRE(lower_machine_state.visits == 1);
+        BOOST_REQUIRE(visits == 3);
+        upper_machine.visit_current_states(reset_count_visitor, visits);
+
+        upper_machine.stop();
+        upper_machine.visit_current_states(count_visitor, visits);
+        BOOST_REQUIRE(visits == 0);
+    }
+}
+

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -35,6 +35,7 @@ test-suite msm-unit-tests
     [ run AnonymousAndGuard.cpp ]
     [ run AnonymousEuml.cpp ]
     [ run Back11CompositeMachine.cpp ]
+    [ run Backmp11Visitor.cpp ]
     [ run BigWithFunctors.cpp ]
     # MSVC 32-bit runs out of memory when compiling this test
     [ run CompositeEuml.cpp : : : <toolset>msvc-14.3,<address-model>32:<build>no ]


### PR DESCRIPTION
Reworked the visitor implementation in backmp11 and some other details in the same area.

The new version uses perfecgt forwarding and a dispatch table mechanism, similar to the dispatch table for event processing.
This removes the need to initialize a `m_visitors` member at runtime.

More information about resolved limitations and bugs is mentioned in the README.md under backmp11's include dir.