### PR TITLE
Remove eUML & proto support in backmp11

### DIFF
--- a/include/boost/msm/backmp11/README.md
+++ b/include/boost/msm/backmp11/README.md
@@ -20,6 +20,30 @@ It is named after the metaprogramming library Boost Mp11, the main contributor t
     - If the SM was stopped, the last active state(s) were visited
 
 
+## New features
+
+## Resolved limitations
+
+## Breaking changes
+
+### The targeted minimum C++ version is C++17
+
+C++11 brings the strongly needed variadic template support for MSM, but later C++ versions provide other important features - for example C++17's `if constexpr`.
+
+
+### The eUML frontend is not supported
+
+The support of EUML induces longer compilation times by the need to include the Boost proto headers and applying C++03 variadic template emulation. If you want to use a UML-like syntax, please try out the new PUML frontend.
+
+
+### The backend's constructor does not allow initialization of states and `set_states` is not available
+
+There were some caveats with one constructor that was used for different use cases: On the one hand some arguments were immediately forwarded to the frontend's constructor, on the other hand the stream operator was used to identify other arguments in the constructor as states, to copy them into the state machine. Besides the syntax of the later being rather unusual, when doing both at once the syntax becomes too difficult to understand; even more so if states within hierarchical sub state machines were initialized in this fashion.
+
+In order to keep API of the constructor simpler and less ambiguous, it only supports forwarding arguments to the frontend and no more.
+Also the `set_states` API is removed. If setting a state is required, this can still be done (in a little more verbose, but also more direct & explicit fashion) by getting a reference to the desired state via `get_state` and then assigning the desired new state to it.
+
+
 ## How to use it
 
 The backend and both its policies `favor_runtime_speed` and `favor_compile_time` should be compatible with existing code. Required replacements to try it out:

--- a/test/AnonymousEuml.cpp
+++ b/test/AnonymousEuml.cpp
@@ -9,6 +9,8 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 // back-end
+// EUML is not supported by backmp11
+#define BOOST_MSM_TEST_SKIP_BACKMP11
 #include "BackCommon.hpp"
 #include <boost/msm/front/euml/euml.hpp>
 
@@ -163,6 +165,3 @@ namespace
 
     }
 }
-
-using backmp11_fsm = boost::msm::backmp11::state_machine<my_machine_, boost::msm::backmp11::favor_compile_time>;
-BOOST_MSM_BACKMP11_GENERATE_DISPATCH_TABLE(backmp11_fsm);

--- a/test/BackCommon.hpp
+++ b/test/BackCommon.hpp
@@ -19,8 +19,10 @@ template<typename Front>
 using get_test_machines = boost::mpl::vector<
     boost::msm::back::state_machine<Front>,
     boost::msm::back::state_machine<Front, boost::msm::back::favor_compile_time>,
+#if !defined(BOOST_MSM_TEST_SKIP_BACKMP11)
     boost::msm::backmp11::state_machine<Front>,
     boost::msm::backmp11::state_machine<Front, boost::msm::backmp11::favor_compile_time>,
+#endif // BOOST_MSM_TEST_SKIP_BACKMP11
     boost::msm::back11::state_machine<Front>
     >;
 
@@ -28,8 +30,10 @@ template <template <template <typename...> class, typename = void> class hierarc
 using get_hierarchical_test_machines = boost::mpl::vector<
     hierarchical<boost::msm::back::state_machine>,
     hierarchical<boost::msm::back::state_machine, boost::msm::back::favor_compile_time>,
+#if !defined(BOOST_MSM_TEST_SKIP_BACKMP11)
     hierarchical<boost::msm::backmp11::state_machine>,
     hierarchical<boost::msm::backmp11::state_machine, boost::msm::backmp11::favor_compile_time>,
+#endif // BOOST_MSM_TEST_SKIP_BACKMP11
     hierarchical<boost::msm::back11::state_machine>
 >;
 

--- a/test/Backmp11Constructor.cpp
+++ b/test/Backmp11Constructor.cpp
@@ -1,3 +1,4 @@
+// Copyright 2025 Christian Granzin
 // Copyright 2010 Christophe Henry
 // henry UNDERSCORE christophe AT hotmail DOT com
 // This is an extended version of the state machine available in the boost::mpl library
@@ -9,8 +10,6 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 // back-end
-// set_states API is not supported by backmp11
-#define BOOST_MSM_TEST_SKIP_BACKMP11
 #include "BackCommon.hpp"
 //front-end
 #include <boost/msm/front/state_machine_def.hpp>
@@ -250,8 +249,10 @@ namespace
     typedef Back<player_, Policy> player;
     };
     // Pick a back-end
-    typedef get_hierarchical_test_machines<hierarchical_state_machine> test_machines;
-
+    typedef boost::mpl::vector<
+        hierarchical_state_machine<boost::msm::backmp11::state_machine>,
+        hierarchical_state_machine<boost::msm::backmp11::state_machine, boost::msm::backmp11::favor_compile_time>
+        > test_machines; 
 
     BOOST_AUTO_TEST_CASE_TEMPLATE( test_constructor, test_machine, test_machines )
     {
@@ -259,19 +260,19 @@ namespace
         typedef typename test_machine::player_ player_;
 
         SomeExternalContext ctx(3);
-        player p1(boost::ref(ctx),5);
+        player p1(ctx, 5);
         BOOST_CHECK_MESSAGE(p1.context_.bla == 10,"Wrong returned context value");
 
-        ctx.bla = 3;
-        player p2(msm::back::states_ << typename player_::Empty(1),boost::ref(ctx),5);
-        BOOST_CHECK_MESSAGE(p2.template get_state<typename player_::Empty&>().data_ == 1,"Wrong Empty value");
+        p1.template get_state<typename player_::Empty&>() = typename player_::Empty(1);
+        BOOST_CHECK_MESSAGE(p1.template get_state<typename player_::Empty&>().data_ == 1,"Wrong Empty value");
 
-        p2.set_states(msm::back::states_ << typename player_::Empty(5));
-        BOOST_CHECK_MESSAGE(p2.template get_state<typename player_::Empty&>().data_ == 5,"Wrong Empty value");
+        p1.template get_state<typename player_::Empty&>() = typename player_::Empty(5);
+        BOOST_CHECK_MESSAGE(p1.template get_state<typename player_::Empty&>().data_ == 5,"Wrong Empty value");
 
-        p2.set_states(msm::back::states_ << typename player_::Empty(7) << typename player_::Open(2));
-        BOOST_CHECK_MESSAGE(p2.template get_state<typename player_::Empty&>().data_ == 7,"Wrong Empty value");
-        BOOST_CHECK_MESSAGE(p2.template get_state<typename player_::Open&>().data_ == 2,"Wrong Open value");
+        p1.template get_state<typename player_::Empty&>() = typename player_::Empty(7);
+        p1.template get_state<typename player_::Open&>() = typename player_::Open(2);
+        BOOST_CHECK_MESSAGE(p1.template get_state<typename player_::Empty&>().data_ == 7,"Wrong Empty value");
+        BOOST_CHECK_MESSAGE(p1.template get_state<typename player_::Open&>().data_ == 2,"Wrong Open value");
 
 #if defined(BOOST_MSVC) && BOOST_MSVC >= 1910 && BOOST_MSVC < 1930
 
@@ -284,9 +285,9 @@ namespace
 #else
 
         ctx.bla = 3;
-        player p(msm::back::states_ << typename player_::Empty(1) 
-                                    << typename player_::Playing(msm::back::states_ << typename player_::Playing_::Song1(8)),
-                 boost::ref(ctx),5);
+        player p(ctx, 5);
+        p.template get_state<typename player_::Empty&>() = typename player_::Empty(1);
+        p.template get_state<typename player_::Playing&>().template get_state<typename player_::Playing_::Song1&>() = typename player_::Playing_::Song1(8);
         BOOST_CHECK_MESSAGE(p.template get_state<typename player_::Playing&>().template get_state<typename player_::Playing_::Song1&>().data_ == 8,"Wrong Open value");
 
 #endif

--- a/test/CompositeEuml.cpp
+++ b/test/CompositeEuml.cpp
@@ -8,6 +8,8 @@
 // file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
+// EUML is not supported by backmp11
+#define BOOST_MSM_TEST_SKIP_BACKMP11
 #include "BackCommon.hpp"
 #include <boost/msm/front/euml/euml.hpp>
 
@@ -289,8 +291,3 @@ namespace
 using back0 = hierarchical_state_machine<boost::msm::back::state_machine, boost::msm::back::favor_compile_time>::player;
 using back1 = hierarchical_state_machine<boost::msm::back::state_machine, boost::msm::back::favor_compile_time>::Playing_type;
 BOOST_MSM_BACK_GENERATE_PROCESS_EVENT(back1);
-
-using backmp11_0 = hierarchical_state_machine<boost::msm::backmp11::state_machine, boost::msm::backmp11::favor_compile_time>::player;
-BOOST_MSM_BACKMP11_GENERATE_DISPATCH_TABLE(backmp11_0);
-using backmp11_1 = hierarchical_state_machine<boost::msm::backmp11::state_machine, boost::msm::backmp11::favor_compile_time>::Playing_type;
-BOOST_MSM_BACKMP11_GENERATE_DISPATCH_TABLE(backmp11_1);

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -35,6 +35,7 @@ test-suite msm-unit-tests
     [ run AnonymousAndGuard.cpp ]
     [ run AnonymousEuml.cpp ]
     [ run Back11CompositeMachine.cpp ]
+    [ run Backmp11Constructor.cpp ]
     [ run Backmp11Visitor.cpp ]
     [ run BigWithFunctors.cpp ]
     # MSVC 32-bit runs out of memory when compiling this test

--- a/test/OrthogonalDeferredEuml.cpp
+++ b/test/OrthogonalDeferredEuml.cpp
@@ -155,9 +155,7 @@ namespace
     // Pick a back-end
     typedef boost::mpl::vector<
         hierarchical_state_machine<boost::msm::back::state_machine>,
-        hierarchical_state_machine<boost::msm::back::state_machine, boost::msm::back::favor_compile_time>,
-        hierarchical_state_machine<boost::msm::backmp11::state_machine>,
-        hierarchical_state_machine<boost::msm::backmp11::state_machine, boost::msm::backmp11::favor_compile_time>
+        hierarchical_state_machine<boost::msm::back::state_machine, boost::msm::back::favor_compile_time>
         // TODO:
         // Investigate reason for test failure in back11.
         // hierarchical_state_machine<boost::msm::back11::state_machine>
@@ -375,8 +373,3 @@ namespace
 using back0 = hierarchical_state_machine<boost::msm::back::state_machine, boost::msm::back::favor_compile_time>::player;
 using back1 = hierarchical_state_machine<boost::msm::back::state_machine, boost::msm::back::favor_compile_time>::Playing_type;
 BOOST_MSM_BACK_GENERATE_PROCESS_EVENT(back1);
-
-using backmp11_0 = hierarchical_state_machine<boost::msm::backmp11::state_machine, boost::msm::backmp11::favor_compile_time>::player;
-BOOST_MSM_BACKMP11_GENERATE_DISPATCH_TABLE(backmp11_0);
-using backmp11_1 = hierarchical_state_machine<boost::msm::backmp11::state_machine, boost::msm::backmp11::favor_compile_time>::Playing_type;
-BOOST_MSM_BACKMP11_GENERATE_DISPATCH_TABLE(backmp11_1);

--- a/test/SerializeSimpleEuml.cpp
+++ b/test/SerializeSimpleEuml.cpp
@@ -8,6 +8,8 @@
 // file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
+// EUML is not supported by backmp11
+#define BOOST_MSM_TEST_SKIP_BACKMP11
 #include "BackCommon.hpp"
 #include <boost/msm/front/euml/euml.hpp>
 
@@ -213,6 +215,3 @@ namespace
 // at the risk of a programming error creating duplicate objects.
 // this is to get rid of warning because p is not const
 // BOOST_CLASS_TRACKING(player, boost::serialization::track_never)
-
-using backmp11_fsm = boost::msm::backmp11::state_machine<player_, boost::msm::backmp11::favor_compile_time>;
-BOOST_MSM_BACKMP11_GENERATE_DISPATCH_TABLE(backmp11_fsm);

--- a/test/SetStates.cpp
+++ b/test/SetStates.cpp
@@ -9,6 +9,8 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 // back-end
+// set_states API is not supported by backmp11
+#define BOOST_MSM_TEST_SKIP_BACKMP11
 #include "BackCommon.hpp"
 //front-end
 #include <boost/msm/front/state_machine_def.hpp>

--- a/test/SimpleEuml.cpp
+++ b/test/SimpleEuml.cpp
@@ -8,6 +8,8 @@
 // file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
+// EUML is not supported by backmp11
+#define BOOST_MSM_TEST_SKIP_BACKMP11
 #include "BackCommon.hpp"
 #include <boost/msm/front/euml/euml.hpp>
 
@@ -193,6 +195,3 @@ namespace
                             "Stopped entry not called correctly");
     }
 }
-
-using backmp11_fsm = boost::msm::backmp11::state_machine<player_, boost::msm::backmp11::favor_compile_time>;
-BOOST_MSM_BACKMP11_GENERATE_DISPATCH_TABLE(backmp11_fsm);

--- a/test/SimpleEuml2.cpp
+++ b/test/SimpleEuml2.cpp
@@ -8,6 +8,8 @@
 // file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
+// EUML is not supported by backmp11
+#define BOOST_MSM_TEST_SKIP_BACKMP11
 #include "BackCommon.hpp"
 #include <boost/msm/front/euml/euml.hpp>
 
@@ -193,6 +195,3 @@ namespace
                             "Stopped entry not called correctly");
     }
 }
-
-using backmp11_fsm = boost::msm::backmp11::state_machine<player_, boost::msm::backmp11::favor_compile_time>;
-BOOST_MSM_BACKMP11_GENERATE_DISPATCH_TABLE(backmp11_fsm);

--- a/test/SimpleInternalEuml.cpp
+++ b/test/SimpleInternalEuml.cpp
@@ -8,6 +8,8 @@
 // file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
+// EUML is not supported by backmp11
+#define BOOST_MSM_TEST_SKIP_BACKMP11
 #include "BackCommon.hpp"
 #include <boost/msm/front/euml/euml.hpp>
 #ifndef BOOST_MSM_NONSTANDALONE_TEST
@@ -251,6 +253,3 @@ namespace
                             "Stopped entry not called correctly");
     }
 }
-
-using backmp11_fsm = boost::msm::backmp11::state_machine<player_, boost::msm::backmp11::favor_compile_time>;
-BOOST_MSM_BACKMP11_GENERATE_DISPATCH_TABLE(backmp11_fsm);


### PR DESCRIPTION
Remove eUML support in backmp11, as eUML is deprecated and the support in the backend requires inclusion of eUML headers and boost proto headers.

Also remove the `set_states` API to get rid of the last boost proto dependency. An alternative to set states is described in the README.