### PR TITLE
backmp11: Remove unnecessary headers

### DIFF
--- a/include/boost/msm/backmp11/metafunctions.hpp
+++ b/include/boost/msm/backmp11/metafunctions.hpp
@@ -47,8 +47,6 @@
 #include <boost/mpl/back_inserter.hpp>
 #include <boost/mpl/transform.hpp>
 
-#include <boost/fusion/include/insert_range.hpp>
-
 #include <boost/type_traits/is_same.hpp>
 #include <boost/utility/enable_if.hpp>
 

--- a/include/boost/msm/backmp11/state_machine.hpp
+++ b/include/boost/msm/backmp11/state_machine.hpp
@@ -22,25 +22,13 @@
 #include <boost/core/ignore_unused.hpp>
 #include <boost/mp11.hpp>
 #include <boost/mp11/mpl_list.hpp>
-#include <boost/mpl/contains.hpp>
 #include <boost/mpl/deref.hpp>
 #include <boost/mpl/assert.hpp>
-
-#include <boost/fusion/container/vector/convert.hpp>
-#include <boost/fusion/include/as_vector.hpp>
-#include <boost/fusion/include/as_set.hpp>
-#include <boost/fusion/container/set.hpp>
-#include <boost/fusion/include/set.hpp>
-#include <boost/fusion/include/set_fwd.hpp>
-#include <boost/fusion/include/mpl.hpp>
-#include <boost/fusion/sequence/intrinsic/at_key.hpp>
-#include <boost/fusion/include/at_key.hpp>
-#include <boost/fusion/algorithm/iteration/for_each.hpp>
-#include <boost/fusion/include/for_each.hpp>
 
 #include <boost/assert.hpp>
 #include <boost/ref.hpp>
 #include <boost/type_traits/remove_pointer.hpp>
+#include <boost/type_traits/add_reference.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_convertible.hpp>
 
@@ -2241,9 +2229,6 @@ private:
         template <class State>
         void operator()( State const&) const
         {
-            //create a new state with the defined id and type
-            BOOST_STATIC_CONSTANT(int, state_id = (get_state_id<stt,State>::value));
-
             this->new_state_helper<State>(),
             create_state_helper<State>::set_sm(self);
         }


### PR DESCRIPTION
Remove not needed headers from backmp11.

Header inclusions of boost::bind and boost::function are completely removed when building with backmp11
The headers of boost::fusion are not directly included anymore in backmp11, though they are still present due to transitive dependencies.

Related to https://github.com/boostorg/msm/issues/106