### PR TITLE
back: Revert const qualifier removals in the execute methods

### DIFF
--- a/include/boost/msm/back/dispatch_table.hpp
+++ b/include/boost/msm/back/dispatch_table.hpp
@@ -57,7 +57,7 @@ struct dispatch_table
             template <class Sequence>
             static
             HandledEnum
-            execute(Fsm& , int, int, Event& , ::boost::mpl::true_ const & )
+            execute(Fsm& , int, int, Event const& , ::boost::mpl::true_ const & )
             {
                 // if at least one guard rejected, this will be ignored, otherwise will generate an error
                 return HANDLED_FALSE;
@@ -66,7 +66,7 @@ struct dispatch_table
             template <class Sequence>
             static
             HandledEnum
-            execute(Fsm& fsm, int region_index , int state, Event& evt,
+            execute(Fsm& fsm, int region_index , int state, Event const& evt,
                     ::boost::mpl::false_ const & )
             {
                  // try the first guard
@@ -89,7 +89,7 @@ struct dispatch_table
             }
         };
         // Take the transition action and return the next state.
-        static HandledEnum execute(Fsm& fsm, int region_index, int state, Event& evt)
+        static HandledEnum execute(Fsm& fsm, int region_index, int state, Event const& evt)
         {
             // forward to helper
             return execute_helper::template execute<Seq>(fsm,region_index,state,evt,

--- a/include/boost/msm/back/state_machine.hpp
+++ b/include/boost/msm/back/state_machine.hpp
@@ -419,7 +419,7 @@ private:
             return false;
         }
         // Take the transition action and return the next state.
-        static HandledEnum execute(library_sm& fsm, int region_index, int state, transition_event& evt)
+        static HandledEnum execute(library_sm& fsm, int region_index, int state, transition_event const& evt)
         {
 
             BOOST_STATIC_CONSTANT(int, current_state = (get_state_id<stt,current_state_type>::type::value));
@@ -564,7 +564,7 @@ private:
         >::type next_state_type;
 
         // Take the transition action and return the next state.
-        static HandledEnum execute(library_sm& fsm, int region_index, int state, transition_event& evt)
+        static HandledEnum execute(library_sm& fsm, int region_index, int state, transition_event const& evt)
         {
             BOOST_STATIC_CONSTANT(int, current_state = (get_state_id<stt,current_state_type>::type::value));
             BOOST_STATIC_CONSTANT(int, next_state = (get_state_id<stt,next_state_type>::type::value));


### PR DESCRIPTION
Revert some of the changes applied in 

https://github.com/boostorg/msm/commit/c287cc097ea6c7afeee1c9b47e06f7671095ede8#diff-8609ca70fabeda64e1fbfe75da5348516160df6c765c137d1e4cbb301bcdae51

to fix the issue described in https://github.com/boostorg/msm/issues/87

TODOs:

- [ ] Regression test added