### PR TITLE
backmp11: refactorings, optimizations, reset method

### DIFF
--- a/include/boost/msm/backmp11/README.md
+++ b/include/boost/msm/backmp11/README.md
@@ -46,10 +46,23 @@ A new method `is_state_active` can be used to check whether a state is currently
 
 ```cpp
 template <typename State>
-bool state_machine::is_state_active() const
+bool state_machine::is_state_active() const;
 ```
 
 If the type of the state appears multiple times in a hierarchical state machine, the method returns true if any of the states are active.
+
+
+### Method to reset the state machine
+
+A new method `reset()` can be used to reset the state machine back to its initial state after construction.
+
+```cpp
+void state_machine::reset();
+```
+
+The behaviors are start and stop are:
+- if `start()` is called for a running state machine, the call is ignored
+- if `stop()` is called on a stopped (not running) state machine, the call is ignored
 
 
 ### Simplified state machine signature

--- a/include/boost/msm/backmp11/history_impl.hpp
+++ b/include/boost/msm/backmp11/history_impl.hpp
@@ -27,18 +27,18 @@ template <int NumberOfRegions>
 class history_impl<front::no_history, NumberOfRegions>
 {
   public:
-    void set_initial_states(const std::array<int, NumberOfRegions>& initial_state_ids)
+    void reset_active_state_ids(const std::array<int, NumberOfRegions>& initial_state_ids)
     {
         m_initial_state_ids = initial_state_ids;
     }
 
     template <class Event>
-    const std::array<int, NumberOfRegions>& history_entry(Event const&)
+    const std::array<int, NumberOfRegions>& on_entry(Event const&)
     {
         return m_initial_state_ids;
     }
 
-    void history_exit(const std::array<int, NumberOfRegions>&)
+    void on_exit(const std::array<int, NumberOfRegions>&)
     {
         // ignore
     }
@@ -62,18 +62,18 @@ template <int NumberOfRegions>
 class history_impl<front::always_shallow_history, NumberOfRegions>
 {
 public:
-    void set_initial_states(const std::array<int, NumberOfRegions>& initial_state_ids)
+    void reset_active_state_ids(const std::array<int, NumberOfRegions>& initial_state_ids)
     {
         m_last_active_state_ids = initial_state_ids;
     }
 
     template <class Event>
-    const std::array<int, NumberOfRegions>& history_entry(Event const& )
+    const std::array<int, NumberOfRegions>& on_entry(Event const& )
     {
         return m_last_active_state_ids;
     }
 
-    void history_exit(const std::array<int, NumberOfRegions>& active_state_ids)
+    void on_exit(const std::array<int, NumberOfRegions>& active_state_ids)
     {
         m_last_active_state_ids = active_state_ids;
     }
@@ -99,14 +99,14 @@ class history_impl<front::shallow_history<Events...>, NumberOfRegions>
     using events_mp11 = mp11::mp_list<Events...>;
 
 public:
-    void set_initial_states(const std::array<int, NumberOfRegions>& initial_state_ids)
+    void reset_active_state_ids(const std::array<int, NumberOfRegions>& initial_state_ids)
     {
         m_initial_state_ids = initial_state_ids;
         m_last_active_state_ids = initial_state_ids;
     }
 
     template <class Event>
-    const std::array<int, NumberOfRegions>& history_entry(Event const&)
+    const std::array<int, NumberOfRegions>& on_entry(Event const&)
     {
         if constexpr (mp11::mp_contains<events_mp11,Event>::value)
         {
@@ -115,7 +115,7 @@ public:
         return m_initial_state_ids;
     }
 
-    void history_exit(const std::array<int, NumberOfRegions>& active_state_ids)
+    void on_exit(const std::array<int, NumberOfRegions>& active_state_ids)
     {
         m_last_active_state_ids = active_state_ids;
     }

--- a/test/Backmp11.hpp
+++ b/test/Backmp11.hpp
@@ -149,7 +149,7 @@ struct serialize_state
     typename ::boost::enable_if<
         typename ::boost::mpl::or_<
             typename has_do_serialize<T>::type,
-            typename is_composite_state<T>::type
+            typename has_back_end_tag<T>::type
         >::type
         ,void
     >::type
@@ -161,7 +161,7 @@ struct serialize_state
     typename ::boost::disable_if<
         typename ::boost::mpl::or_<
             typename has_do_serialize<T>::type,
-            typename is_composite_state<T>::type
+            typename has_back_end_tag<T>::type
         >::type
         ,void
     >::type

--- a/test/Backmp11Members.cpp
+++ b/test/Backmp11Members.cpp
@@ -38,19 +38,17 @@ namespace
     struct MyAction
     {
         template<typename Event, typename Fsm, typename Source, typename Target>
-        void operator()(const Event&, Fsm&, Source&, Target&)
+        void operator()(const Event&, Fsm& fsm, Source&, Target&)
         {
-            // TODO
-            // fsm.action_calls++;
+            fsm.action_calls++;
         }
     };
     struct MyGuard
     {
         template<typename Event, typename Fsm, typename Source, typename Target>
-        bool operator()(const Event&, Fsm&, Source&, Target&) const
+        bool operator()(const Event&, Fsm& fsm, Source&, Target&) const
         {
-            // TODO
-            // fsm.guard_calls++;
+            fsm.guard_calls++;
             return true;
         }
     };
@@ -66,6 +64,7 @@ namespace
     {
         using context = Context;
         using root_sm = StateMachine;
+        // using fsm_parameter = root_sm;
     };
 
     struct StateMachine_ : public state_machine_def<StateMachine_>
@@ -79,10 +78,9 @@ namespace
         };
 
         template <typename Event, typename Fsm>
-        void on_exit(const Event& /*event*/, Fsm& /*fsm*/)
+        void on_exit(const Event& /*event*/, Fsm& fsm)
         {
-            // TODO
-            // fsm.machine_exits++;
+            fsm.machine_exits++;
         };
 
         using initial_state = Default;
@@ -117,10 +115,10 @@ namespace
         test_machine.start();
         BOOST_CHECK_MESSAGE(test_machine.entry_calls == 1, "SM on_entry not called correctly");
         test_machine.process_event(MyEvent{});
-        // BOOST_CHECK_MESSAGE(test_machine.action_calls == 1, "SM action not called correctly");
-        // BOOST_CHECK_MESSAGE(test_machine.guard_calls == 1, "SM guard not called correctly");
+        BOOST_CHECK_MESSAGE(test_machine.action_calls == 1, "SM action not called correctly");
+        BOOST_CHECK_MESSAGE(test_machine.guard_calls == 1, "SM guard not called correctly");
 
         test_machine.stop();
-        // BOOST_CHECK_MESSAGE(test_machine.machine_exits == 1, "SM on_exit not called correctly");
+        BOOST_CHECK_MESSAGE(test_machine.machine_exits == 1, "SM on_exit not called correctly");
     }
 }


### PR DESCRIPTION
Applied changes in backmp11:

- Removed leftovers from eUML support
- Removed most of the MPL occurrences
- Removed most of the helper structs
- Removed unused metafunctions
- Optimized O(N) dispatches to O(1) in entries and exits
- Aligned internal API names
- Implemented a reset method