### PR TITLE
feat/backmp11: visitor, constructor, fsm_parameter

### DIFF
--- a/include/boost/msm/backmp11/common_types.hpp
+++ b/include/boost/msm/backmp11/common_types.hpp
@@ -22,13 +22,31 @@ using process_result = back::HandledEnum;
 
 using any_event = std::any;
 
-// Tag referring to active states of a SM.
-struct active_states_t {};
-constexpr active_states_t active_states;
+// Selector for the visit mode.
+// Can be active_states or all_states in recursive
+// or non-recursive mode.
+enum class visit_mode
+{
+    // State selection (mutually exclusive).
+    active_states = 0b001,
+    all_states    = 0b010,
 
-// Tag referring to all states of a SM.
-struct all_states_t {};
-constexpr all_states_t all_states;
+    // Traversal mode (not set = non-recursive).
+    recursive     = 0b100,
+
+    // All valid combinations.
+    active_non_recursive = active_states,
+    active_recursive     = active_states | recursive,
+    all_non_recursive    = all_states,
+    all_recursive        = all_states | recursive
+};
+constexpr visit_mode operator|(visit_mode lhs, visit_mode rhs)
+{
+    return static_cast<visit_mode>(
+        static_cast<std::underlying_type_t<visit_mode>>(lhs) |
+        static_cast<std::underlying_type_t<visit_mode>>(rhs)
+    );
+}
 
 namespace detail
 {

--- a/include/boost/msm/backmp11/detail/metafunctions.hpp
+++ b/include/boost/msm/backmp11/detail/metafunctions.hpp
@@ -19,15 +19,15 @@
 #include <boost/mpl/is_sequence.hpp>
 #include <boost/mpl/front.hpp>
 
-
 #include <boost/type_traits/is_same.hpp>
 #include <boost/utility/enable_if.hpp>
 
 #include <boost/msm/row_tags.hpp>
 
+#include <boost/msm/backmp11/common_types.hpp>
 #include <boost/msm/back/traits.hpp>
-#include <boost/msm/back/default_compile_policy.hpp>
 #include <boost/msm/front/detail/common_states.hpp>
+
 
 namespace boost { namespace msm { namespace backmp11
 {
@@ -35,13 +35,24 @@ namespace boost { namespace msm { namespace backmp11
 namespace detail
 {
 
+constexpr bool has_flag(visit_mode value, visit_mode flag)
+{
+    return (static_cast<int>(value) & static_cast<int>(flag)) != 0;
+}
+
 struct back_end_tag {};
 
 template <typename T>
 using has_back_end_tag = std::is_same<typename T::internal::tag, back_end_tag>;
 
+template <class T>
+using is_back_end = has_back_end_tag<T>;
+
 template <typename T>
-inline constexpr bool is_composite_v = std::is_same_v<typename T::internal::tag, msm::front::detail::composite_state_tag> || has_back_end_tag<T>::value;
+using is_composite = mp11::mp_or<
+    std::is_same<typename T::internal::tag, msm::front::detail::composite_state_tag>,
+    has_back_end_tag<T>
+    >;
 
 // Call a functor on all elements of List, until the functor returns true.
 template <typename List, typename Func>

--- a/include/boost/msm/backmp11/favor_compile_time.hpp
+++ b/include/boost/msm/backmp11/favor_compile_time.hpp
@@ -191,8 +191,7 @@ struct compile_policy_impl<favor_compile_time>
                     [this](auto event_identity)
                     {
                         using Event = typename decltype(event_identity)::type;
-                        // using test = print_types<Event>;
-                        auto& chain_row = get_chain_row<Event>();
+                        chain_row& chain_row = this->get_chain_row<Event>();
                         chain_row.one_state.push_front(reinterpret_cast<generic_cell>(&Fsm::template execute_defer_transition<any_event>));
                     });
 

--- a/include/boost/msm/backmp11/state_machine_config.hpp
+++ b/include/boost/msm/backmp11/state_machine_config.hpp
@@ -17,6 +17,16 @@
 namespace boost::msm::backmp11
 {
 
+namespace detail
+{
+
+struct config_tag {};
+// Check whether a type is a config.
+template <class T>
+using is_config = std::is_same<typename T::internal::tag, config_tag>;
+
+}
+
 // Config for the default compile policy
 // (runtime over compile time).
 struct favor_runtime_speed;
@@ -34,8 +44,8 @@ struct no_context {};
 struct no_root_sm {};
 
 // Config for the default fsm parameter
-// (processing fsm)
-struct processing_sm{};
+// (transition owner)
+struct transition_owner{};
 
 // Default state machine config.
 struct default_state_machine_config
@@ -43,9 +53,14 @@ struct default_state_machine_config
     using compile_policy = favor_runtime_speed;
     using context = no_context;
     using root_sm = no_root_sm;
-    using fsm_parameter = processing_sm;
+    using fsm_parameter = transition_owner;
     template<typename T>
     using queue_container = std::deque<T>;
+
+    struct internal
+    {
+        using tag = detail::config_tag;
+    };
 };
 
 using state_machine_config = default_state_machine_config;

--- a/test/Backmp11.hpp
+++ b/test/Backmp11.hpp
@@ -9,7 +9,8 @@
 // file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-#include "boost/msm/backmp11/state_machine_config.hpp"
+#include "boost/msm/backmp11/state_machine.hpp"
+#include "boost/msm/backmp11/favor_compile_time.hpp"
 
 namespace boost::msm::backmp11
 {

--- a/test/Backmp11Adapter.hpp
+++ b/test/Backmp11Adapter.hpp
@@ -168,9 +168,12 @@ struct serialize_state
     Archive& ar_;
 };
 
+namespace detail
+{
+
 template <class Archive, class FrontEnd, class Config, class Derived>
 void serialize(Archive& ar,
-               msm::backmp11::state_machine<FrontEnd, Config, Derived>& sm)
+               state_machine_base<FrontEnd, Config, Derived>& sm)
 {
     (serialize_state<Archive>(ar))(boost::serialization::base_object<FrontEnd>(sm));
     ar & sm.m_active_state_ids;
@@ -178,9 +181,6 @@ void serialize(Archive& ar,
     ar & sm.m_event_processing;
     mp11::tuple_for_each(sm.m_states, serialize_state<Archive>(ar));
 }
-
-namespace detail
-{
 
 template<typename T, int N>
 void serialize(T& ar, detail::history_impl<front::no_history, N>& history)
@@ -207,7 +207,7 @@ void serialize(Archive& ar,
                msm::backmp11::state_machine_adapter<A0, A1, A2, A3, A4>& sm,
                const unsigned int /*version*/)
 {
-    msm::backmp11::serialize(ar, sm);
+    msm::backmp11::detail::serialize(ar, sm);
 }
 
 template<typename T, int N>

--- a/test/Backmp11Context.cpp
+++ b/test/Backmp11Context.cpp
@@ -10,7 +10,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 // back-end
-#include <boost/msm/backmp11/state_machine.hpp>
+#include "Backmp11.hpp"
 //front-end
 #include <boost/msm/front/state_machine_def.hpp>
 #include <boost/msm/front/functor_row.hpp>
@@ -31,56 +31,59 @@ using namespace msm::backmp11;
 
 namespace
 {
-    // Events.
-    struct EnterSubFsm{};
-    struct ExitSubFsm{};
 
-    // Context.
-    struct Context
+// Events.
+struct EnterSubFsm{};
+struct ExitSubFsm{};
+
+// Context.
+struct Context
+{
+    uint32_t machine_entries = 0;
+    uint32_t machine_exits = 0;
+};
+template<typename Fsm>
+static Context& get_context(Fsm& fsm)
+{
+    return fsm.get_context();
+}
+
+// States.
+struct Default : public state<>{};
+
+template<typename T>
+struct MachineBase_ : public state_machine_def<MachineBase_<T>>
+{
+    template <typename Event, typename Fsm>
+    void on_entry(const Event& /*event*/, Fsm& fsm)
     {
-        uint32_t machine_entries = 0;
-        uint32_t machine_exits = 0;
+        Context& context = get_context(fsm);
+        context.machine_entries++;
     };
-    template<typename Fsm>
-    static Context& get_context(Fsm& fsm)
+
+    template <typename Event, typename Fsm>
+    void on_exit(const Event& /*event*/, Fsm& fsm)
     {
-        return fsm.get_context();
-    }
+        get_context(fsm).machine_exits++;
+    };
 
-    // States.
-    struct Default : public state<>{};
+    using initial_state = Default;
+};
 
-    // Forward-declare the upper machine,
-    // so we can set a root_sm.
+
+template <bool WithRootSm, bool WithFavorCompileTime>
+struct Test
+{
     class UpperMachine;
 
-    struct SmConfig : state_machine_config
-    {
+    struct Config : default_state_machine_config {
         using context = Context;
-        using root_sm = UpperMachine;
-    };
-
-    template<typename T>
-    struct MachineBase_ : public state_machine_def<MachineBase_<T>>
-    {
-        template <typename Event, typename Fsm>
-        void on_entry(const Event& /*event*/, Fsm& fsm)
-        {
-            Context& context = get_context(fsm);
-            context.machine_entries++;
-        };
-
-        template <typename Event, typename Fsm>
-        void on_exit(const Event& /*event*/, Fsm& fsm)
-        {
-            get_context(fsm).machine_exits++;
-        };
-
-        using initial_state = Default;
+        using root_sm = mp11::mp_if_c<WithRootSm, UpperMachine, no_root_sm>;
+        using compile_policy = mp11::mp_if_c<WithFavorCompileTime, favor_compile_time, favor_runtime_speed>;
     };
 
     struct LowerMachine_ : public MachineBase_<LowerMachine_> {};
-    using LowerMachine = state_machine<LowerMachine_, SmConfig>;
+    using LowerMachine = state_machine<LowerMachine_, Config>;
 
     struct MiddleMachine_ : public MachineBase_<MiddleMachine_>
     {
@@ -89,44 +92,88 @@ namespace
             Row< LowerMachine , ExitSubFsm  , Default      >
         >;
     };
-    using MiddleMachine = state_machine<MiddleMachine_, SmConfig>;
+    using MiddleMachine = state_machine<MiddleMachine_, Config>;
 
     struct UpperMachine_ : public MachineBase_<UpperMachine_>
     {
+        UpperMachine_() = default;
+
+        UpperMachine_(bool optional_argument) : optional_argument(optional_argument) {}
+
         using transition_table = mp11::mp_list<
             Row< Default       , EnterSubFsm , MiddleMachine>,
             Row< MiddleMachine , ExitSubFsm  , Default>
         >;
+
+        bool optional_argument;
     };
-    class UpperMachine : public state_machine<UpperMachine_, SmConfig, UpperMachine>
+    class UpperMachine : public state_machine<UpperMachine_, Config, UpperMachine>
     {
-      public:
-        using Base = state_machine<UpperMachine_, SmConfig, UpperMachine>;
+        public:
+        using Base = state_machine<UpperMachine_, Config, UpperMachine>;
         using Base::Base;
     };
 
-    BOOST_AUTO_TEST_CASE( backmp11_context_test )
+    static void run()
     {
-        Context context;
-        UpperMachine test_machine{context};
+        // Test with only context.
+        {
+            Context context;
+            UpperMachine test_machine{context};
+            BOOST_ASSERT(&test_machine.get_context() == &context);
+            auto& middle_machine = test_machine.template get_state<MiddleMachine>();
+            BOOST_ASSERT(&middle_machine.get_context() == &context);
+            // Suppress warnings in case the assert is not present.
+            [[maybe_unused]] auto& lower_machine = middle_machine.template get_state<LowerMachine>();
+            BOOST_ASSERT(&lower_machine.get_context() == &context);
+            process_events(test_machine);
+        }
 
+        // Test with context and additional constructor argument.
+        {
+            Context context;
+            UpperMachine test_machine{context, true};
+            BOOST_ASSERT(test_machine.optional_argument == true);
+            BOOST_ASSERT(&test_machine.get_context() == &context);
+            auto& middle_machine = test_machine.template get_state<MiddleMachine>();
+            BOOST_ASSERT(&middle_machine.get_context() == &context);
+            // Suppress warnings in case the assert is not present.
+            [[maybe_unused]] auto& lower_machine = middle_machine.template get_state<LowerMachine>();
+            BOOST_ASSERT(&lower_machine.get_context() == &context);
+            BOOST_ASSERT(&lower_machine.get_context() == &context);
+            process_events(test_machine);
+        }
+    };
+
+    static void process_events(UpperMachine& test_machine)
+    {
         test_machine.start(); 
-        BOOST_CHECK_MESSAGE(test_machine.get_context().machine_entries == 1, "SM entry not called correctly");
+        BOOST_CHECK(test_machine.get_context().machine_entries == 1);
 
         test_machine.process_event(EnterSubFsm()); 
-        BOOST_CHECK_MESSAGE(test_machine.get_context().machine_entries == 2, "SM entry not called correctly");
+        BOOST_CHECK(test_machine.get_context().machine_entries == 2);
 
         test_machine.process_event(EnterSubFsm()); 
-        BOOST_CHECK_MESSAGE(test_machine.get_context().machine_entries == 3, "SM entry not called correctly");
+        BOOST_CHECK(test_machine.get_context().machine_entries == 3);
 
         test_machine.process_event(ExitSubFsm()); 
-        BOOST_CHECK_MESSAGE(test_machine.get_context().machine_exits == 1, "SM exit not called correctly");
+        BOOST_CHECK(test_machine.get_context().machine_exits == 1);
 
         test_machine.process_event(ExitSubFsm()); 
-        BOOST_CHECK_MESSAGE(test_machine.get_context().machine_exits == 2, "SM exit not called correctly");
+        BOOST_CHECK(test_machine.get_context().machine_exits == 2);
 
         test_machine.stop(); 
-        BOOST_CHECK_MESSAGE(test_machine.get_context().machine_exits == 3, "SM exit not called correctly");
-    }
+        BOOST_CHECK(test_machine.get_context().machine_exits == 3);
+    };
+};
+
+BOOST_AUTO_TEST_CASE( backmp11_context_test )
+{
+    Test<false, false>::run();
+    Test<false, true>::run();
+    Test<true, false>::run();
+    Test<true, true>::run();
 }
+
+} // namespace
 

--- a/test/Backmp11Visitor.cpp
+++ b/test/Backmp11Visitor.cpp
@@ -78,9 +78,11 @@ namespace
     struct DefaultState : public state<StateBase> {};
 
     template<typename T>
-    struct MachineBase_ : public state_machine_def<MachineBase_<T>, StateBase>
+    struct MachineBase_ : public state_machine_def<MachineBase_<T>>
     {
         using initial_state = DefaultState;
+
+        size_t visits;
     };
 
     template<typename Config = default_state_machine_config>
@@ -170,16 +172,23 @@ namespace
             upper_machine.visit(count_visitor);
             BOOST_REQUIRE(visits == 0);
         }
+        using vm = msm::backmp11::visit_mode;
 
         // Test all states
         {
-            upper_machine.visit(count_visitor, all_states);
-            BOOST_REQUIRE(upper_machine_state.visits == 1);
-            BOOST_REQUIRE(middle_machine.visits == 1);
-            BOOST_REQUIRE(middle_machine_state.visits == 1);
-            BOOST_REQUIRE(lower_machine.visits == 1);
-            BOOST_REQUIRE(lower_machine_state.visits == 1);
-            BOOST_REQUIRE(visits == 5);
+            upper_machine.template visit<vm::all_states>(count_visitor);
+            BOOST_CHECK(upper_machine_state.visits == 1);
+            BOOST_CHECK(middle_machine.visits == 1);
+            BOOST_CHECK(visits == 2);
+            upper_machine.template visit<vm::all_states>(reset_count_visitor);
+
+            upper_machine.template visit<vm::all_recursive>(count_visitor);
+            BOOST_CHECK(upper_machine_state.visits == 1);
+            BOOST_CHECK(middle_machine.visits == 1);
+            BOOST_CHECK(middle_machine_state.visits == 1);
+            BOOST_CHECK(lower_machine.visits == 1);
+            BOOST_CHECK(lower_machine_state.visits == 1);
+            BOOST_CHECK(visits == 5);
         }
     }
 }

--- a/test/OrthogonalDeferredEuml.cpp
+++ b/test/OrthogonalDeferredEuml.cpp
@@ -155,7 +155,6 @@ namespace
     // Pick a back-end
     typedef boost::mpl::vector<
         hierarchical_state_machine<boost::msm::back::state_machine>
-        // hierarchical_state_machine<boost::msm::back::state_machine, boost::msm::back::favor_compile_time>
         // TODO:
         // Investigate reason for test failure in back11.
         // hierarchical_state_machine<boost::msm::back11::state_machine>
@@ -369,9 +368,3 @@ namespace
 
     }
 }
-
-#if !defined(BOOST_MSM_TEST_ONLY_BACKMP11)
-using back0 = hierarchical_state_machine<boost::msm::back::state_machine, boost::msm::back::favor_compile_time>::player;
-using back1 = hierarchical_state_machine<boost::msm::back::state_machine, boost::msm::back::favor_compile_time>::Playing_type;
-BOOST_MSM_BACK_GENERATE_PROCESS_EVENT(back1);
-#endif


### PR DESCRIPTION
Applied changes:
- Improved and extended the visitor API to be easier to use. It now supports 4 different combinations which states to visit and uses an enum for selection instead of tag dispatch
- Improved the constructor to resolve ambiguities when Derived is not set. Also some fixes and lots of compile time assertions for wrongly instantiated state machines
- Corrected the name default fsm parameter; used transition owner for now, because it's not the processing sm