### PR TITLE
feat/backmp11: rework after review

### DIFF
--- a/include/boost/msm/backmp11/README.md
+++ b/include/boost/msm/backmp11/README.md
@@ -315,7 +315,7 @@ It can be copied and adapted if needed, though this class is internal to the tes
 
 Further details about the applied API changes:
 
-#### Support for `boost::serialization` is removed
+#### The dependency to `boost::serialization` is removed
 
 The back-end aims to support serialization in general, but without providing a concrete implementation for a specific serialization library.
 If you want to use `boost::serialization` for your state machine, you can look into the [state machine adapter](../../../../test/Backmp11Adapter.hpp) from the tests for an example how to set it up.

--- a/include/boost/msm/backmp11/detail/favor_runtime_speed.hpp
+++ b/include/boost/msm/backmp11/detail/favor_runtime_speed.hpp
@@ -17,8 +17,14 @@
 #include <boost/msm/backmp11/event_traits.hpp>
 
 #include <boost/mpl/advance.hpp>
+#include <boost/mpl/begin.hpp>
+#include <boost/mpl/bool.hpp>
 #include <boost/mpl/empty.hpp>
 #include <boost/mpl/erase.hpp>
+#include <boost/mpl/eval_if.hpp>
+#include <boost/mpl/front.hpp>
+#include <boost/mpl/identity.hpp>
+#include <boost/mpl/int.hpp>
 #include <boost/mpl/pair.hpp>
 #include <boost/mpl/pop_front.hpp>
 

--- a/include/boost/msm/backmp11/state_machine.hpp
+++ b/include/boost/msm/backmp11/state_machine.hpp
@@ -23,7 +23,11 @@
 
 #include <boost/mp11.hpp>
 
-#include <boost/mpl/for_each.hpp>
+#include <boost/mpl/eval_if.hpp>
+#include <boost/mpl/identity.hpp>
+#include <boost/mpl/is_sequence.hpp>
+#include <boost/mpl/bool.hpp>
+#include <boost/mpl/and.hpp>
 
 #include <boost/assert.hpp>
 #include <boost/ref.hpp>


### PR DESCRIPTION
Applied changes:
- Included boost::mpl headers explicitly
- Changed formulation from "support for boost::serialization is removed" to "dependency to boost::serialization is removed"