### PR TITLE
fix/backmp11: UML event deferral

### DIFF
--- a/doc/modules/ROOT/pages/tutorial/backmp11-back-end.adoc
+++ b/doc/modules/ROOT/pages/tutorial/backmp11-back-end.adoc
@@ -1,7 +1,7 @@
 = Backmp11 back-end (C{plus}{plus}17, experimental)
 
 Backmp11 is a new back-end that is mostly backwards-compatible with `back`.
-It is currently in **experimental** stage, thus some details about the compatibility might change (feedback welcome!). 
+It is currently in **experimental** stage, thus some details about the compatibility might change (feedback welcome!).
 It is named after the metaprogramming library Boost Mp11, the main contributor to the optimizations.
 Usages of MPL are replaced with Mp11 to get rid of the costly C{plus}{plus}03 emulation of variadic templates.
 
@@ -13,36 +13,61 @@ The new back-end has the following goals:
 
 It offers a significant reduction in compilation time and RAM usage, as can be seen in these benchmarks:
 
-**Large state machine**
+*Large state machine*
 
-[width=80%, cols="4*", options="header"]
+[width=80%, cols="3,1,1,1", options="header"]
 |=======================================================================
 |                             | Compile / sec | RAM / MB | Runtime / sec
-| back                        | 18            | 953      | 7            
-| back_favor_compile_time     | 21            | 1000     | 8            
-| back11                      | 43            | 2794     | 7            
-| backmp11                    | 4             | 261      | 3            
-| backmp11_favor_compile_time | 3             | 231      | 13           
-| boost-ext/sml               | 12            | 363      | 3            
+| back                        | 18            | 953      | 7
+| back_favor_compile_time     | 21            | 1000     | 8
+| back11                      | 43            | 2794     | 7
+| backmp11                    | 3             | 239      | 3
+| backmp11_favor_compile_time | 3             | 220      | 13
+| sml                         | 12            | 363      | 3
 |=======================================================================
 
 
-**Large hierarchical state machine**
+*Large hierarchical state machine*
 
-[width=80%, cols="4*", options="header"]
+[width=80%, cols="3,1,1,1", options="header"]
 |================================================================================
 |                                      | Compile / sec | RAM / MB | Runtime / sec
-| back                                 | 68            | 2849     | 23           
-| back_favor_compile_time              | 80            | 2551     | 261          
-| backmp11                             | 12            | 525      | 10           
-| backmp11_favor_compile_time          | 7             | 318      | 40           
-| backmp11_favor_compile_time_multi_cu | 5             | ~982     | 40           
-| boost-ext/sml                        | 48            | 1128     | 11           
+| back                                 | 68            | 2849     | 23
+| back_favor_compile_time              | 80            | 2551     | 261
+| backmp11                             | 11            | 472      | 10
+| backmp11_favor_compile_time          | 7             | 288      | 40
+| backmp11_favor_compile_time_multi_cu | 5             | ~919     | 40
+| sml                                  | 48            | 1128     | 11
 |================================================================================
 
 
-The full code with the benchmarks and more information about them https://github.com/chandryan/fsm-benchmarks[is available here].
+The full code with the benchmarks and more information about them is available https://github.com/chandryan/fsm-benchmarks[in this repository].
 There are still a couple more optimizations to come, the tables in the repository frequently get updated with the latest results.
+
+
+== Deprecation timeline
+
+Deprecations of features with more context information are listed in below table.
+
+[width=95%, cols="16,5,40"]
+|===
+| Feature | Deprecation / Removal | Description
+
+| Support for event deferral as action and public access to the deferred event container
+| 1.90 / 1.91
+a| Deferring an event as an action triggered by the same event is not foreseen in UML and leads to ambiguities (the event is both consumed and deferred).
+
+*Change:* The public API to defer an event will be changed to `protected`. If needed, users can inherit from `state_machine` and make the API public again, but without guarantees about correct functionality and API consistency.
+
+*Recommendation:* Configure event deferral as a state property instead of using it as a transition action.
+
+| Public access to the event container
+| 1.90 / 1.91
+a| The event container can be accessed and manipulated via public APIs. Manipulation of the container outside of the library code can lead to undefined behavior.
+
+*Change:* The public API to access the event container will be changed to `protected`. If needed, users can inherit from `state_machine` to access the event container, but without guarantees about correct functionality and API consistency.
+
+|===
 
 
 == New features
@@ -98,6 +123,7 @@ void operator()(State& state);
 ```
 
 Also these bugs are fixed:
+
 - If the SM is not started yet, no active state is visited instead of the initial state(s)
 - If the SM is stopped, no active state is visited instead of the last active state(s)
 
@@ -233,7 +259,19 @@ A similar friend declaration is available in the `history_impl` classes.
 **IMPORTANT:** This design allows you to provide any serializer implementation, but due to the need to access private members there is no guarantee that your implementation breaks in a new version of the back-end.
 
 
-== Changes with respect to `back`
+== Resolved issues with respect to `back`
+
+=== Deferring events in orthogonal regions
+
+Event deferral in orthogonal regions behaves as described in the UML standard:
+
+- If one active region decides to defer an event, then it is deferred for all regions instead of being processed
+- The event gets processed once no more active region decides to defer it
+
+In `back` the event is evaluted by all regions independently. This leads to the same event being processed multiple times (and worst case to infinite recursion).
+
+
+== Other changes with respect to `back`
 
 === The required minimum C{plus}{plus} version is C{plus}{plus}17
 
@@ -406,7 +444,7 @@ Required replacements to try it out:
 
 - for the state machine use `boost::msm::backmp11::state_machine` in place of `boost::msm::back::state_machine` and
 - for configuring the compile policy and more use `boost::msm::backmp11::state_machine_config`
-- if you encounter API-incompatibilities please check the [details above](=changes-with-respect-to-back) for reference
+- if you encounter API-incompatibilities please check the <<_other_changes_with_respect_to_back,details above>> for reference
 
 
 Since the back-end should compile very fast for most machines, the manual generation of state machines with the `favor_compile_time` policy has become an opt-in feature.
@@ -432,8 +470,8 @@ Below you can find some insights how the compile-time and runtime optimizations 
 
 Summary:
 
+- Unconditionally default-initialized everything first and afterwards only the row-related transition cells
 - Optimized cell initialization with initializer arrays (to reduce template instantiations)
-- Default-initialized everything first and afterwards only the defer transition cells
 
 
 === `favor_compile_time` policy

--- a/include/boost/msm/backmp11/common_types.hpp
+++ b/include/boost/msm/backmp11/common_types.hpp
@@ -50,8 +50,18 @@ constexpr visit_mode operator|(visit_mode lhs, visit_mode rhs)
 
 namespace detail
 {
-    using EventSource = back::EventSourceEnum;
-    using back::HandledEnum;
+
+using EventSource = back::EventSourceEnum;
+using back::HandledEnum;
+
+constexpr EventSource operator|(EventSource lhs, EventSource rhs)
+{
+    return static_cast<EventSource>(
+        static_cast<std::underlying_type_t<EventSource>>(lhs) |
+        static_cast<std::underlying_type_t<EventSource>>(rhs)
+    );
+}
+
 }
 
 }}} // namespace boost::msm::backmp11

--- a/test/BackCommon.hpp
+++ b/test/BackCommon.hpp
@@ -59,8 +59,6 @@ using get_hierarchical_test_machines = boost::mpl::vector<
 #endif // BOOST_MSM_TEST_ONLY_BACKMP11
 >;
 
-#undef BOOST_MSM_TEST_MAYBE_COMMA
-
 #define BOOST_MSM_TEST_DEFINE_DEPENDENT_TEMPLATES(frontname)                          \
     using base = msm::front::state_machine_def<frontname>;                            \
     template<typename T1, class Event, typename T2>                                   \

--- a/test/Backmp11Deferred.cpp
+++ b/test/Backmp11Deferred.cpp
@@ -1,0 +1,241 @@
+// Copyright 2025 Christian Granzin
+// Copyright 2010 Christophe Henry
+// henry UNDERSCORE christophe AT hotmail DOT com
+// This is an extended version of the state machine available in the boost::mpl library
+// Distributed under the same license as the original.
+// Copyright for the original version:
+// Copyright 2005 David Abrahams and Aleksey Gurtovoy. Distributed
+// under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+// back-end
+#include "BackCommon.hpp"
+// front-end
+#include <boost/msm/front/state_machine_def.hpp>
+#include <boost/msm/front/functor_row.hpp>
+
+#ifndef BOOST_MSM_NONSTANDALONE_TEST
+#define BOOST_TEST_MODULE backmp11_deferred
+#endif
+#include <boost/test/unit_test.hpp>
+
+using namespace boost::msm::front;
+using namespace boost::msm::backmp11;
+
+namespace mp11 = boost::mp11;
+
+// Events
+struct Event1 {};
+struct Event2 {};
+struct ManualDeferEvent {};
+struct FromHandleAllToHandleNone {};
+struct FromHandleNoneToHandleAll {};
+struct FromDeferEvent1And2ToDeferEvent1 {};
+struct FromDeferEvent1ToHandleNone {};
+
+// Actions
+struct Action
+{
+    template <typename Fsm, typename SourceState, typename TargetState>
+    void operator()(const Event1&, Fsm& fsm, SourceState&, TargetState&)
+    {
+        fsm.event1_action_calls++;
+    }
+
+    template <typename Fsm, typename SourceState, typename TargetState>
+    void operator()(const Event2&, Fsm& fsm, SourceState&, TargetState&)
+    {
+        fsm.event2_action_calls++;
+    }
+};
+
+// Common states
+struct StateHandleNone : state<> {};
+struct StateHandleAll : state<> {};
+
+template<typename T>
+struct StateMachineBase_ : state_machine_def<T> 
+{
+    bool check_and_reset_event1_action_calls(size_t expected)
+    {
+        const bool result = (event1_action_calls == expected);
+        event1_action_calls = 0;
+        return result;
+    }
+
+    bool check_and_reset_event2_action_calls(size_t expected)
+    {
+        const bool result = (event2_action_calls == expected);
+        event2_action_calls = 0;
+        return result;
+    }
+
+    size_t event1_action_calls{};
+    size_t event2_action_calls{};
+};
+
+namespace uml_deferred
+{
+
+struct StateDeferEvent1 : state<>
+{
+    using deferred_events = mp11::mp_list<Event1>;
+};
+
+struct StateDeferEvent1And2 : state<>
+{
+    using deferred_events = mp11::mp_list<Event1, Event2>;
+};
+
+struct StateMachine_ : StateMachineBase_<StateMachine_> 
+{
+    using initial_state =
+        mp11::mp_list<StateHandleAll, StateDeferEvent1, StateDeferEvent1And2>;
+
+    using transition_table = mp11::mp_list<
+        Row<StateHandleNone      , FromHandleNoneToHandleAll        , StateHandleAll   , none  >,
+        Row<StateHandleAll       , FromHandleAllToHandleNone        , StateHandleNone  , none  >,
+        Row<StateDeferEvent1And2 , FromDeferEvent1And2ToDeferEvent1 , StateDeferEvent1 , none  >,
+        Row<StateDeferEvent1     , FromDeferEvent1ToHandleNone      , StateHandleNone  , none  >,
+        Row<StateHandleAll       , Event1                           , none             , Action>,
+        Row<StateHandleAll       , Event2                           , none             , Action>,
+        Row<StateHandleAll       , ManualDeferEvent                 , none             , Defer  >
+    >;
+};
+
+// Pick a back-end
+using Fsms = mp11::mp_list<
+#ifndef BOOST_MSM_TEST_SKIP_BACKMP11
+    state_machine<StateMachine_>,
+    state_machine<StateMachine_, favor_compile_time_config>
+#endif // BOOST_MSM_TEST_SKIP_BACKMP11
+    >;
+
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(uml_deferred, Fsm, Fsms)
+{     
+    Fsm fsm;
+
+    fsm.start();
+    
+    fsm.process_event(Event1{});
+    BOOST_REQUIRE(fsm.check_and_reset_event1_action_calls(0));
+    BOOST_REQUIRE(fsm.check_and_reset_event2_action_calls(0));
+    BOOST_REQUIRE(fsm.get_deferred_events_queue().size() == 1);
+    
+    fsm.process_event(Event2{});
+    BOOST_REQUIRE(fsm.check_and_reset_event1_action_calls(0));
+    BOOST_REQUIRE(fsm.check_and_reset_event2_action_calls(0));
+    BOOST_REQUIRE(fsm.get_deferred_events_queue().size() == 2);
+    
+    fsm.process_event(FromDeferEvent1And2ToDeferEvent1{});
+    BOOST_REQUIRE(fsm.check_and_reset_event1_action_calls(0));
+    BOOST_REQUIRE(fsm.check_and_reset_event2_action_calls(1));
+    BOOST_REQUIRE(fsm.get_deferred_events_queue().size() == 1);
+    
+    fsm.process_event(FromDeferEvent1ToHandleNone{});
+    BOOST_REQUIRE(fsm.check_and_reset_event1_action_calls(1));
+    BOOST_REQUIRE(fsm.check_and_reset_event2_action_calls(0));
+    BOOST_REQUIRE(fsm.get_deferred_events_queue().size() == 0);
+
+    fsm.process_event(ManualDeferEvent{});
+    BOOST_REQUIRE(fsm.check_and_reset_event1_action_calls(0));
+    BOOST_REQUIRE(fsm.check_and_reset_event2_action_calls(0));
+    BOOST_REQUIRE(fsm.get_deferred_events_queue().size() == 1);
+
+    // The new event gets deferred: +1
+    // The deferred event gets consumed and deferred again: -1, +1
+    fsm.process_event(ManualDeferEvent{});
+    BOOST_REQUIRE(fsm.check_and_reset_event1_action_calls(0));
+    BOOST_REQUIRE(fsm.check_and_reset_event2_action_calls(0));
+    BOOST_REQUIRE(fsm.get_deferred_events_queue().size() == 2);
+
+    fsm.stop();
+}
+
+} // namespace uml_deferred
+
+// Test case for manual deferral by using transitions with Defer actions.
+// Not specified in UML and thus no clear semantics how it should behave.
+// Currently a Defer action consumes the event (it gets removed from the queue)
+// and then defers it (it gets pushed back to the queue), the Defer action
+// returns HANDLED_DEFERRED as processing result).
+namespace action_deferred
+{
+
+struct StateDeferEvent1 : state<>
+{
+};
+
+struct StateDeferEvent1And2 : state<>
+{
+};
+
+struct StateMachine_ : StateMachineBase_<StateMachine_> 
+{
+    using activate_deferred_events = int;
+    using initial_state =
+        mp11::mp_list<StateHandleAll, StateDeferEvent1And2>;
+
+    using transition_table = mp11::mp_list<
+        Row<StateHandleNone      , FromHandleNoneToHandleAll        , StateHandleAll   , none  >,
+        Row<StateHandleAll       , FromHandleAllToHandleNone        , StateHandleNone  , none  >,
+        Row<StateDeferEvent1And2 , FromDeferEvent1And2ToDeferEvent1 , StateDeferEvent1 , none  >,
+        Row<StateDeferEvent1     , FromDeferEvent1ToHandleNone      , StateHandleNone  , none  >,
+        Row<StateDeferEvent1     , Event1                           , none             , Defer >,
+        Row<StateDeferEvent1And2 , Event1                           , none             , Defer >,
+        Row<StateDeferEvent1And2 , Event2                           , none             , Defer >,
+        Row<StateHandleAll       , Event1                           , none             , Action>,
+        Row<StateHandleAll       , Event2                           , none             , Action>
+    >;
+};
+
+// Pick a back-end
+using Fsms = mp11::mp_list<
+#ifndef BOOST_MSM_TEST_SKIP_BACKMP11
+    state_machine<StateMachine_>,
+    state_machine<StateMachine_, favor_compile_time_config>
+#endif // BOOST_MSM_TEST_SKIP_BACKMP11
+    >;
+
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(action_deferred, Fsm, Fsms)
+{     
+    Fsm fsm;
+
+    fsm.start();
+    
+    fsm.process_event(Event1{});
+    // Processed by StateHandleAll, deferred by StateDeferEvent1And2.
+    // Queue: Event1
+    BOOST_REQUIRE(fsm.check_and_reset_event1_action_calls(1));
+    BOOST_REQUIRE(fsm.get_deferred_events_queue().size() == 1);
+    
+    fsm.process_event(Event2{});
+    // Processed by StateHandleAll, deferred by StateDeferEvent1And2.
+    // StateHandleAll also processes Event1 again.
+    // Queue: Event2, Event1
+    BOOST_REQUIRE(fsm.check_and_reset_event1_action_calls(1));
+    BOOST_REQUIRE(fsm.check_and_reset_event2_action_calls(1));
+    BOOST_REQUIRE(fsm.get_deferred_events_queue().size() == 2);
+    
+    fsm.process_event(FromDeferEvent1And2ToDeferEvent1{});
+    // Event2 is no more deferred.
+    // StateHandleAll processes Event2 & Event1,
+    // StateDeferEvent1 defers Event1.
+    // Queue: Event1
+    BOOST_REQUIRE(fsm.check_and_reset_event1_action_calls(1));
+    BOOST_REQUIRE(fsm.check_and_reset_event2_action_calls(1));
+    BOOST_REQUIRE(fsm.get_deferred_events_queue().size() == 1);
+    
+    fsm.process_event(FromDeferEvent1ToHandleNone{});
+    // Event1 is no more deferred.
+    // StateHandleAll processes Event1.
+    BOOST_REQUIRE(fsm.check_and_reset_event1_action_calls(1));
+    BOOST_REQUIRE(fsm.get_deferred_events_queue().size() == 0);
+
+    fsm.stop();
+}
+
+} // namespace action_deferred

--- a/test/Backmp11ManyDeferTransitions.cpp
+++ b/test/Backmp11ManyDeferTransitions.cpp
@@ -1,0 +1,196 @@
+// Copyright 2024 Christophe Henry
+// henry UNDERSCORE christophe AT hotmail DOT com
+// This is an extended version of the state machine available in the boost::mpl library
+// Distributed under the same license as the original.
+// Copyright for the original version:
+// Copyright 2005 David Abrahams and Aleksey Gurtovoy. Distributed
+// under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+// back-end
+#include "BackCommon.hpp"
+//front-end
+#include <boost/msm/front/functor_row.hpp>
+#include <boost/msm/front/state_machine_def.hpp>
+#ifndef BOOST_MSM_NONSTANDALONE_TEST
+#define BOOST_TEST_MODULE backmp11_many_defer_transitions
+#endif
+#include <boost/test/unit_test.hpp>
+
+using namespace boost::msm::front;
+using namespace boost::msm::backmp11;
+namespace mp11 = boost::mp11;
+
+// Events
+struct Event1 {};
+struct Event2 {};
+struct Event3 {};
+struct Event4 {};
+
+namespace uml_defer_transitions
+{
+
+// States
+struct State1 : state<>
+{
+    using deferred_events = mp11::mp_list<Event1, Event2, Event3>;
+};
+struct State2 : state<>
+{
+    using deferred_events = mp11::mp_list<Event1, Event3>;
+};
+struct State3 : state<>
+{
+};
+struct State4 : state<>
+{
+};
+struct State5 : state<>
+{
+};
+
+// ----- State machine
+struct Sm1_ : state_machine_def<Sm1_>
+{
+    // Set initial state
+    typedef State1 initial_state;
+    // Enable deferred capability
+    typedef int activate_deferred_events;
+    // Transition table
+    using transition_table = mp11::mp_list<
+        //    Start   Event   Next    Action
+        Row < State1, Event4, State2, none >,
+
+        Row < State2, Event2, State3, none >,
+
+        Row < State3, Event1, State4, none >,
+        Row < State3, Event3, State5, none >,
+        Row < State4, Event3, State5, none >,
+        Row < State5, Event1, State4, none >
+    >;
+};
+
+// Pick a back-end
+using TestMachines = mp11::mp_list<
+#ifndef BOOST_MSM_TEST_SKIP_BACKMP11
+    state_machine<Sm1_>,
+    state_machine<Sm1_, favor_compile_time_config>
+#endif // BOOST_MSM_TEST_SKIP_BACKMP11
+    >;
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(uml_defer_transitions, TestMachine, TestMachines)
+{
+    TestMachine state_machine;
+    state_machine.start();
+    
+    state_machine.process_event(Event1());
+    // Queue: Event1
+    BOOST_REQUIRE(state_machine.get_deferred_events_queue().size() == 1);
+    
+    state_machine.process_event(Event2());
+    // Queue: Event1, Event2
+    BOOST_REQUIRE(state_machine.get_deferred_events_queue().size() == 2);
+    
+    state_machine.process_event(Event3());
+    // Queue: Event1, Event2, Event3
+    BOOST_REQUIRE(state_machine.get_deferred_events_queue().size() == 3);
+    
+    state_machine.process_event(Event4());
+    // Event4 gets consumed, new state is State2.
+    // Event1 stays deferred (queue: Event1, Event2, Event3)
+    // Event2 gets consumed, new state is State3 (queue: Event1, Event3)
+    // Event1 gets consumed, new state is State4 (queue: Event3)
+    // Event3 gets consumed, new state is State5
+    BOOST_REQUIRE(state_machine.get_deferred_events_queue().size() == 0);
+    BOOST_REQUIRE(state_machine.template is_state_active<State5>());
+}
+
+} // namespace uml_defer_transitions
+
+// Test case for manual deferral by using transitions with Defer actions.
+// Not specified in UML and thus no clear semantics how it should behave.
+// Currently a Defer action consumes the event (it gets removed from the queue)
+// and then defers it (it gets pushed back to the queue), the Defer action
+// returns HANDLED_DEFERRED as processing result).
+namespace action_defer_transitions
+{
+
+// States
+struct State1 : state<>
+{
+};
+struct State2 : state<>
+{
+};
+struct State3 : state<>
+{
+};
+struct State4 : state<>
+{
+};
+struct State5 : state<>
+{
+};
+
+// ----- State machine
+struct Sm1_ : state_machine_def<Sm1_>
+{
+    // Set initial state
+    typedef State1 initial_state;
+    // Enable deferred capability
+    typedef int activate_deferred_events;
+    // Transition table
+    using transition_table = mp11::mp_list<
+        //    Start   Event   Next    Action
+        Row < State1, Event1, none  , Defer>,
+        Row < State1, Event2, none  , Defer>,
+        Row < State1, Event3, none  , Defer>,
+        Row < State1, Event4, State2, none >,
+
+        Row < State2, Event3, none  , Defer>,
+        Row < State2, Event1, none  , Defer>,
+        Row < State2, Event2, State3, none >,
+
+        Row < State3, Event1, State4, none >,
+        Row < State3, Event3, State5, none >,
+        Row < State4, Event3, State5, none >,
+        Row < State5, Event1, State4, none >
+    >;
+};
+
+// Pick a back-end
+using TestMachines = mp11::mp_list<
+#ifndef BOOST_MSM_TEST_SKIP_BACKMP11
+    state_machine<Sm1_>,
+    state_machine<Sm1_, favor_compile_time_config>
+#endif // BOOST_MSM_TEST_SKIP_BACKMP11
+    >;
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(action_defer_transitions, TestMachine, TestMachines)
+{
+    TestMachine state_machine;
+    state_machine.start();
+    
+    state_machine.process_event(Event1());
+    // Queue: Event1
+    BOOST_REQUIRE(state_machine.get_deferred_events_queue().size() == 1);
+    
+    state_machine.process_event(Event2());
+    // Queue: Event2, Event1
+    BOOST_REQUIRE(state_machine.get_deferred_events_queue().size() == 2);
+    
+    state_machine.process_event(Event3());
+    // Queue: Event3, Event2, Event1
+    BOOST_REQUIRE(state_machine.get_deferred_events_queue().size() == 3);
+    
+    state_machine.process_event(Event4());
+    // Event4 gets consumed, new state is State2.
+    // Event3 gets deferred (queue: Event2, Event1, Event3)
+    // Event2 gets consumed, new state is State3 (queue: Event1, Event3)
+    // Event1 gets consumed, new state is State4 (queue: Event3)
+    BOOST_REQUIRE(state_machine.get_deferred_events_queue().size() == 1);
+    BOOST_REQUIRE(state_machine.template is_state_active<State4>());
+}
+
+} // namespace action_defer_transitions

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -74,6 +74,8 @@ add_executable(boost_msm_cxx17_tests
     EXCLUDE_FROM_ALL
     Backmp11Constructor.cpp
     Backmp11Context.cpp
+    Backmp11Deferred.cpp
+    Backmp11ManyDeferTransitions.cpp
     Backmp11Members.cpp
     Backmp11RootSm.cpp
     Backmp11Visitor.cpp

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -78,6 +78,8 @@ test-suite msm-unit-tests-cxxstd17
     :
     [ run Backmp11Constructor.cpp ]
     [ run Backmp11Context.cpp ]
+    [ run Backmp11Deferred.cpp ]
+    [ run Backmp11ManyDeferTransitions.cpp ]
     [ run Backmp11Members.cpp ]
     [ run Backmp11Visitor.cpp ]
     [ run Backmp11RootSm.cpp ]

--- a/test/ManyDeferTransitions.cpp
+++ b/test/ManyDeferTransitions.cpp
@@ -8,6 +8,8 @@
 // file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
+// Event deferral behaves differently in backmp11
+#define BOOST_MSM_TEST_SKIP_BACKMP11
 // back-end
 #include "BackCommon.hpp"
 //front-end

--- a/test/OrthogonalDeferred3.cpp
+++ b/test/OrthogonalDeferred3.cpp
@@ -342,11 +342,14 @@ namespace
     };
     // Pick a back-end
     typedef boost::mpl::vector<
-        hierarchical_state_machine<boost::msm::back::state_machine>,
 #if !defined(BOOST_MSM_TEST_SKIP_BACKMP11)
-        hierarchical_state_machine<boost::msm::backmp11::state_machine_adapter>,
+        hierarchical_state_machine<boost::msm::backmp11::state_machine_adapter>
+        BOOST_MSM_TEST_MAYBE_COMMA
 #endif
+#if !defined(BOOST_MSM_TEST_ONLY_BACKMP11)
+        hierarchical_state_machine<boost::msm::back::state_machine>,
         hierarchical_state_machine<boost::msm::back11::state_machine>
+#endif
         > test_machines;
 
     //static char const* const state_names[] = { "Stopped", "Open", "Empty", "Playing", "Paused","AllOk","ErrorMode" };

--- a/test/TestDeferIn2Regions.cpp
+++ b/test/TestDeferIn2Regions.cpp
@@ -8,13 +8,15 @@
 // file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
+// Event deferral behaves differently in backmp11
+#define BOOST_MSM_TEST_SKIP_BACKMP11
 // back-end
 #include "BackCommon.hpp"
 //front-end
 #include <boost/msm/front/state_machine_def.hpp>
 #include <boost/msm/front/functor_row.hpp>
 #ifndef BOOST_MSM_NONSTANDALONE_TEST
-#define BOOST_TEST_MODULE Back11TestDeferIn2Regions
+#define BOOST_TEST_MODULE TestDeferIn2Regions
 #endif
 #include <boost/test/unit_test.hpp>
 
@@ -120,7 +122,7 @@ namespace
     // Pick a back-end
     typedef get_test_machines<player_> players;
 
-    BOOST_AUTO_TEST_CASE_TEMPLATE( Back11TestDeferIn2Regions, player, players )
+    BOOST_AUTO_TEST_CASE_TEMPLATE(TestDeferIn2Regions, player, players)
     {
         player p;
         // needed to start the highest-level SM. This will call on_entry and mark the start of the SM


### PR DESCRIPTION
Fix the event deferral mechanism to be UML-compliant.

Related to https://github.com/boostorg/msm/issues/143
Related to https://github.com/boostorg/msm/issues/72