### PR TITLE
Remove macos-13 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,9 +114,6 @@ jobs:
             install: clang-20
           - toolset: clang
             cxxstd: "11,14,17,20,2b"
-            os: macos-13
-          - toolset: clang
-            cxxstd: "11,14,17,20,2b"
             os: macos-14
           - toolset: clang
             cxxstd: "11,14,17,20,2b"


### PR DESCRIPTION
Remove macos-13 from the CI, as it's not supported anymore by GitHub