### PR TITLE
feat(backmp11): conditional deferred_events

### DIFF
--- a/doc/modules/ROOT/pages/tutorial/backmp11-back-end.adoc
+++ b/doc/modules/ROOT/pages/tutorial/backmp11-back-end.adoc
@@ -316,6 +316,27 @@ This design allows you to provide any serializer implementation, but due to the 
 ====
 
 
+=== Support for conditional event deferral with the `deferred_events` property
+
+In `back` & `back11`, the events mentioned in a state's `deferred_events` property are always deferred.
+In `backmp11``, they can be deferred conditionally by defining a method `is_event_deferred` for them:
+
+```cpp
+struct MyState : boost::msm::front::state<>
+{
+    using deferred_events = mp11::mp_list<MyEvent>;
+
+    template <typename Fsm>
+    bool is_event_deferred(const MyEvent& event, Fsm& fsm) const
+    {
+        // Return false or true to decide
+        // whether the event shall be deferred.
+        ...
+    }
+};
+```
+
+
 == Resolved issues with respect to `back`
 
 === Deferring events in orthogonal regions
@@ -463,7 +484,7 @@ Also the `set_states` API is removed. If setting a state is required, this can s
 ==== The method `get_state_by_id` is removed
 
 If you really need to get a state by id, please use the universal visitor API to implement the function on your own.
-The backmp11 state_machine has a new method to support getting the id of a state in the visitor:
+The `backmp11` `state_machine` has a new method to support getting the id of a state in the visitor:
 
 ```cpp
 template<typename State>

--- a/doc/modules/ROOT/pages/version-history.adoc
+++ b/doc/modules/ROOT/pages/version-history.adoc
@@ -7,6 +7,7 @@
 * feat(backmp11): Further optimized compilation, with up to 25% faster compile times and less RAM consumption than the 1.90 version
 * fix(backmp11): Incorrect FSM type in call on_entry() & on_exit() (https://github.com/boostorg/msm/issues/167[#167])
 * feat(backmp11): Merge queued & deferred events into a single event pool (https://github.com/boostorg/msm/issues/168[#168])
+* feat(backmp11): Support conditional deferral with the `deferred_events` property (https://github.com/boostorg/msm/issues/155[#155])
 
 == Boost 1.90
 

--- a/include/boost/msm/backmp11/state_machine.hpp
+++ b/include/boost/msm/backmp11/state_machine.hpp
@@ -655,7 +655,7 @@ class state_machine_base : public FrontEnd
         derived_t,
         typename config_t::root_sm>;
 
-    fsm_parameter_t& get_fsm_argument()
+    const fsm_parameter_t& get_fsm_argument() const
     {
         if constexpr (std::is_same_v<typename config_t::fsm_parameter,
                                      local_transition_owner>)
@@ -666,6 +666,12 @@ class state_machine_base : public FrontEnd
         {
             return get_root_sm();
         }
+    }
+
+    fsm_parameter_t& get_fsm_argument()
+    {
+        return const_cast<fsm_parameter_t&>
+            (static_cast<const state_machine_base&>(*this).get_fsm_argument());
     }
 
     // Checks if an event is an end interrupt event.

--- a/include/boost/msm/front/detail/common_states.hpp
+++ b/include/boost/msm/front/detail/common_states.hpp
@@ -70,10 +70,15 @@ struct state_base : public inherit_attributes<Attributes>, USERBASE
 
     // empty implementation for the states not wishing to define an entry condition
     // will not be called polymorphic way
-    template <class Event,class FSM>
-    void on_entry(Event const& ,FSM&){}
-    template <class Event,class FSM>
-    void on_exit(Event const&,FSM& ){}
+    template <class Event, class FSM>
+    void on_entry(Event const&, FSM&) {}
+    template <class Event, class FSM>
+    void on_exit(Event const&, FSM&) {}
+    template <class Event, class FSM>
+    bool is_event_deferred(Event const&, FSM&) const
+    {
+        return true;
+    }
     // default (empty) transition table;
     typedef ::boost::mpl::vector<>  internal_transition_table;
     typedef ::boost::fusion::vector<>  internal_transition_table11;

--- a/include/boost/msm/front/puml/puml.hpp
+++ b/include/boost/msm/front/puml/puml.hpp
@@ -101,6 +101,12 @@ namespace detail {
                     }
                 });
         }
+        // functions added for front::state compatibility
+        template <class Event, class FSM>
+        bool is_event_deferred(Event const&, FSM&) const
+        {
+            return true;
+        }
         // typedefs added for front::state compatibility
         typedef ::boost::mpl::vector<>  internal_transition_table;
         typedef ::boost::fusion::vector<>  internal_transition_table11;

--- a/test/Backmp11Transitions.cpp
+++ b/test/Backmp11Transitions.cpp
@@ -16,8 +16,7 @@
 #include <boost/msm/front/state_machine_def.hpp>
 #include <boost/msm/front/functor_row.hpp>
 
-#include <boost/msm/back/queue_container_circular.hpp>
-#include <boost/msm/back/history_policies.hpp>
+#include "Utils.hpp"
 
 #ifndef BOOST_MSM_NONSTANDALONE_TEST
 #define BOOST_TEST_MODULE backmp11_members_test
@@ -112,8 +111,6 @@ class StateMachine : public state_machine<StateMachine_, SmConfig, StateMachine>
     size_t exit_calls{};
     Counters action_calls{};
 };
-
-#define ASSERT_ONE_AND_RESET(value) BOOST_REQUIRE(value == 1); value = 0
 
 BOOST_AUTO_TEST_CASE( backmp11_members_test )
 {

--- a/test/Utils.hpp
+++ b/test/Utils.hpp
@@ -1,0 +1,19 @@
+// Copyright 2025 Christian Granzin
+// Copyright 2010 Christophe Henry
+// henry UNDERSCORE christophe AT hotmail DOT com
+// This is an extended version of the state machine available in the boost::mpl library
+// Distributed under the same license as the original.
+// Copyright for the original version:
+// Copyright 2005 David Abrahams and Aleksey Gurtovoy. Distributed
+// under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#define ASSERT_AND_RESET(value, expected)                                      \
+    BOOST_REQUIRE(value == expected);                                          \
+    value = 0
+
+#define ASSERT_ONE_AND_RESET(value)                                            \
+    BOOST_REQUIRE(value == 1);                                                 \
+    value = 0
+


### PR DESCRIPTION
New feature for backmp11: Support conditional event deferral with the `deferred_events` property in the states.

Conditional deferral can be implemented by the user via the `is_event_deferred` method, tested in `test/Backmp11Deferred.cpp`.

Related to https://github.com/boostorg/msm/issues/155