### PR TITLE
refactor(backmp11): entry/exit logic

### DIFF
--- a/doc/modules/ROOT/pages/tutorial/backmp11-back-end.adoc
+++ b/doc/modules/ROOT/pages/tutorial/backmp11-back-end.adoc
@@ -34,8 +34,8 @@ It offers a significant reduction in compilation time and RAM usage, as can be s
 |                                      | Compile / sec | RAM / MB | Runtime / sec
 | back                                 | 68            | 2849     | 23
 | back_favor_compile_time              | 80            | 2551     | 261
-| backmp11                             | 8             | 357      | 11
-| backmp11_favor_compile_time          | 6             | 274      | 26
+| backmp11                             | 8             | 350      | 11
+| backmp11_favor_compile_time          | 6             | 266      | 26
 | backmp11_favor_compile_time_multi_cu | 5             | ~915     | 26
 | sml                                  | 40            | 1056     | 11
 |================================================================================

--- a/doc/modules/ROOT/pages/version-history.adoc
+++ b/doc/modules/ROOT/pages/version-history.adoc
@@ -2,10 +2,14 @@
 
 = Version history
 
+== Boost 1.91
+
+* feat(backmp11): Further optimized compilation, with up to 25% faster compile times and less RAM consumption than the 1.90 version
+
 == Boost 1.90
 
-* feat/backmp11: New back-end backmp11, requires C++ 17
-* fix/back: boost::any stopped working as Kleene event (https://github.com/boostorg/msm/issues/87[#87])
+* feat(backmp11): New back-end backmp11, requires C++ 17
+* fix(back): boost::any stopped working as Kleene event (https://github.com/boostorg/msm/issues/87[#87])
 * feat: The documentation has been refurbished, it is now built with Antora
 
 [[boost-185]]

--- a/include/boost/msm/backmp11/detail/metafunctions.hpp
+++ b/include/boost/msm/backmp11/detail/metafunctions.hpp
@@ -347,19 +347,6 @@ struct has_deferred_event_impl<mp11::mp_list<States...>, Event>
 template <typename StateOrStates, typename Event>
 using has_deferred_event = typename has_deferred_event_impl<StateOrStates, Event>::type;
 
-// event used internally for wrapping a direct entry
-template <class State, class Event>
-struct direct_entry_event
-{
-  public:
-    typedef int direct_entry;
-    typedef State active_state;
-    typedef Event contained_event;
-
-    direct_entry_event(Event const& event):m_event(event){}
-    Event const& m_event;
-};
-
 // Builds flags from flag_list + internal_flag_list,
 // internal_flag_list is used for terminate/interrupt states.
 template <typename State>


### PR DESCRIPTION
Applied changes in backmp11:
- Refactored the entry & exit logic
- Removed redundant template instantiations in the entry logic by ruling out impossible entry states when possible