### PR TITLE
docs: retry ui-bundle downloads

### DIFF
--- a/doc/local-playbook.yml
+++ b/doc/local-playbook.yml
@@ -53,6 +53,7 @@ antora:
       cpp-tagfiles:
         using-namespaces:
           - 'boost::'
+    - require: '@cppalliance/antora-downloads-extension'
     # - require: '@cppalliance/antora-cpp-reference-extension'
     #   dependencies:
     #     - name: 'boost'
@@ -74,7 +75,7 @@ content:
   sources:
     - url: .
       start_path: .
-      # edit_url: 'https://github.com/boostorg/msm/edit/{refname}/{path}'
+      edit_url: 'https://github.com/boostorg/msm/edit/develop/{path}'
 
 ui:
   bundle:

--- a/doc/package-lock.json
+++ b/doc/package-lock.json
@@ -9,6 +9,7 @@
         "@asciidoctor/tabs": "^1.0.0-beta.3",
         "@cppalliance/antora-cpp-reference-extension": "^0.0.6",
         "@cppalliance/antora-cpp-tagfiles-extension": "^0.1.0",
+        "@cppalliance/antora-downloads-extension": "^0.0.2",
         "@cppalliance/antora-playbook-macros-extension": "^0.0.2",
         "@cppalliance/asciidoctor-boost-links": "^0.0.2"
       }
@@ -89,6 +90,12 @@
       "dependencies": {
         "process": "^0.11.10"
       }
+    },
+    "node_modules/@cppalliance/antora-downloads-extension": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@cppalliance/antora-downloads-extension/-/antora-downloads-extension-0.0.2.tgz",
+      "integrity": "sha512-2wXahlvRz9J75ZSfzDeP4XpIZiqIm+w/YjmCWJxFPp6oWgP7e8f6ps7HqdtHNGxnK5mG38OjiCFdHjmHYfgbDA==",
+      "license": "BSL-1.0"
     },
     "node_modules/@cppalliance/asciidoctor-boost-links": {
       "version": "0.0.2",

--- a/doc/package.json
+++ b/doc/package.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "@cppalliance/antora-cpp-reference-extension": "^0.0.6",
     "@cppalliance/antora-cpp-tagfiles-extension": "^0.1.0",
+    "@cppalliance/antora-downloads-extension": "^0.0.2",
     "@cppalliance/antora-playbook-macros-extension": "^0.0.2",
     "@cppalliance/asciidoctor-boost-links": "^0.0.2",
     "@antora/lunr-extension": "^1.0.0-alpha.8",


### PR DESCRIPTION
Any download during a CI build might potentially fail so it's convenient to retry. This PR includes a new extension "@cppalliance/antora-downloads-extension" with a retry loop for the ui-bundle. 