### PR TITLE
Fix broken link in functor-front-end.adoc

### DIFF
--- a/doc/modules/ROOT/pages/tutorial/functor-front-end.adoc
+++ b/doc/modules/ROOT/pages/tutorial/functor-front-end.adoc
@@ -88,9 +88,9 @@ top-level one.
 
 To illustrate the reusable point, MSM comes with a whole set of
 predefined functors. Please refer to eUML for the
-link:#Reference-begin[full list]. For example, we are now going to
-replace the first action by an action sequence and the guard by a more
-complex functor.
+xref:reference/euml-operators-and-basic-helpers.adoc[full list]. For
+example, we are now going to replace the first action by an action
+sequence and the guard by a more complex functor.
 
 We decide we now want to execute two actions in the first transition
 (Stopped -> Playing). We only need to change the action start_playback


### PR DESCRIPTION
I respected the 72-columns limit that I found in the rest of the file, so I had to re-wrap the whole paragraph, but it only really changes the broken link.

I haven't tested it locally. I've only read Antora documentation and looked at a few examples to hopefully get the syntax right.

Here's the link for the current page with the broken link: https://www.boost.org/doc/libs/latest/doc/antora/msm/tutorial/functor-front-end.html#transition-table