### PR TITLE
fix(test): make nlohmann/json test opt-in in CMake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,11 +212,6 @@ jobs:
           git submodule update --init tools/boostdep
           python tools/boostdep/depinst/depinst.py --git_args "--jobs 3" $LIBRARY
 
-      - name: Download nlohmann/json
-        run: |
-          cd ../boost-root/libs/$LIBRARY
-          python3 scripts/download_nlohmann_json.py
-
       - name: Configure
         run: |
           cd ../boost-root

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ cmake_minimum_required(VERSION 3.12...3.16)
 
 project(boost_msm VERSION "${BOOST_SUPERPROJECT_VERSION}" LANGUAGES CXX)
 
+option(BOOST_MSM_TEST_NLOHMANN_JSON "Test serialization with nlohmann/json" OFF)
+
 add_library(boost_msm INTERFACE)
 add_library(Boost::msm ALIAS boost_msm)
 

--- a/test/Backmp11Serialization.cpp
+++ b/test/Backmp11Serialization.cpp
@@ -26,7 +26,9 @@
 #include <boost/msm/backmp11/serialization/boost_json.hpp>
 
 // nlohmann/json.
+#ifdef BOOST_MSM_TEST_NLOHMANN_JSON
 #include <boost/msm/backmp11/serialization/nlohmann_json.hpp>
+#endif
 
 using namespace boost::msm;
 namespace mp11 = boost::mp11;
@@ -232,6 +234,8 @@ R"({"front_end":{"brightness":75},"active_state_ids":[1],"event_processing":fals
         BOOST_REQUIRE(dim_switch_2.brightness = 75);
 }
 
+#ifdef BOOST_MSM_TEST_NLOHMANN_JSON
+
 // Helper for convenience:
 // Convert all state ids to a human-readable JSON array
 // to understand which states the ids refer to.
@@ -315,5 +319,7 @@ R"({
     BOOST_REQUIRE(dim_switch.get_state<On>().times_pressed == 1);
     BOOST_REQUIRE(dim_switch_2.brightness = 75);
 }
+
+#endif // BOOST_MSM_TEST_NLOHMANN_JSON
 
 } // namespace

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -96,6 +96,9 @@ add_executable(boost_msm_cxx17_tests
 if(NOT BOOST_MSM_IS_ROOT)
     target_link_libraries(boost_msm_cxx17_tests Boost::json)
 endif()
+if(BOOST_MSM_TEST_NLOHMANN_JSON)
+    target_compile_definitions(boost_msm_cxx17_tests PRIVATE "BOOST_MSM_TEST_NLOHMANN_JSON")
+endif()
 target_compile_features(boost_msm_cxx17_tests PRIVATE cxx_std_17)
 if(((DEFINED CMAKE_CXX_STANDARD)     AND (CMAKE_CXX_STANDARD GREATER_EQUAL 17)) OR
    ((NOT DEFINED CMAKE_CXX_STANDARD) AND ("cxx_std_17" IN_LIST CMAKE_CXX_COMPILE_FEATURES)))

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -87,7 +87,7 @@ test-suite msm-unit-tests-cxxstd17
     [ run Backmp11History.cpp ]
     [ run Backmp11ManyDeferTransitions.cpp ]
     [ run Backmp11RootSm.cpp ]
-    [ run Backmp11Serialization.cpp ]
+    [ run Backmp11Serialization.cpp : : : <define>BOOST_MSM_TEST_NLOHMANN_JSON ]
     [ run Backmp11Transitions.cpp ]
     [ run Backmp11Visitor.cpp ]
     :


### PR DESCRIPTION
Make the nlohmann/json test optional in CMake to fix the superproject CI