### PR TITLE
refactor(backmp11): state machine core

### DIFF
--- a/doc/modules/ROOT/pages/tutorial/backmp11-back-end.adoc
+++ b/doc/modules/ROOT/pages/tutorial/backmp11-back-end.adoc
@@ -15,8 +15,8 @@ It offers a significant improvement in runtime and memory usage, as can be seen 
 | back                        | 10                 | 844              | 73               | 0.7
 | back_favor_compile_time     | 12                 | 821              | 241              | 1.0
 | back11                      | 26                 | 2675             | 92               | 0.7
-| backmp11                    | 2                  | 236              | 20               | 0.4
-| backmp11_favor_compile_time | 2                  | 225              | 45               | 2.3
+| backmp11                    | 2                  | 236              | 18               | 0.2
+| backmp11_favor_compile_time | 2                  | 225              | 44               | 2.2
 | sml                         | 3                  | 242              | 57               | 0.1
 |=======================================================================================================
 
@@ -28,8 +28,8 @@ It offers a significant improvement in runtime and memory usage, as can be seen 
 |                             | Compile time / sec | Compile RAM / MB | Binary size / kB | Runtime / sec
 | back                        | 32                 | 2160             | 252              | 3.7
 | back_favor_compile_time     | 37                 | 1747             | 974              | 263
-| backmp11                    | 5                  | 361              | 48               | 1.7
-| backmp11_favor_compile_time | 3                  | 264              | 97               | 7.5
+| backmp11                    | 5                  | 360              | 55               | 0.9
+| backmp11_favor_compile_time | 3                  | 263              | 96               | 7.5
 | sml                         | 12                 | 567              | 436              | 2.5
 |=======================================================================================================
 
@@ -132,7 +132,7 @@ By default it is set to `local_transition_owner`, which behaves identically to `
 - Actions and guards for transitions in the same transition table receive the SM instance that owns the transition (the one processing the event)
 - Entry and exit actions receive the "local" transition owner from the perspective of the state being entered/exited (the immediate parent SM)
 
-You can alternatively set it to `using fsm_parameter = root_sm`, in which case the configured `root_sm` is passed as the `Fsm` parameter.
+The default setting is useful for accessing members contained in submachines or their front-ends. If access to submachine members is not required, you can set it to `using fsm_parameter = root_sm` instead. The configured `root_sm` will then be passed as the `Fsm` parameter to all actions and guards.
 
 [NOTE]
 ====

--- a/include/boost/msm/backmp11/detail/common.hpp
+++ b/include/boost/msm/backmp11/detail/common.hpp
@@ -13,7 +13,6 @@
 #define BOOST_MSM_BACKMP11_DETAIL_COMMON_HPP
 
 #include <cstdint>
-#include <optional>
 
 #include <boost/msm/backmp11/common_types.hpp>
 
@@ -29,8 +28,7 @@ constexpr HandledEnum operator|(HandledEnum lhs, HandledEnum rhs)
 {
     return static_cast<HandledEnum>(
         static_cast<std::underlying_type_t<HandledEnum>>(lhs) |
-        static_cast<std::underlying_type_t<HandledEnum>>(rhs)
-    );
+        static_cast<std::underlying_type_t<HandledEnum>>(rhs));
 }
 
 constexpr HandledEnum& operator|=(HandledEnum& lhs, HandledEnum rhs)
@@ -43,8 +41,7 @@ constexpr HandledEnum operator&(HandledEnum lhs, HandledEnum rhs)
 {
     return static_cast<HandledEnum>(
         static_cast<std::underlying_type_t<HandledEnum>>(lhs) &
-        static_cast<std::underlying_type_t<HandledEnum>>(rhs)
-    );
+        static_cast<std::underlying_type_t<HandledEnum>>(rhs));
 }
 
 constexpr HandledEnum& operator&=(HandledEnum& lhs, HandledEnum rhs)
@@ -97,84 +94,9 @@ using process_result = back::HandledEnum;
 static constexpr process_result handled_true_or_deferred =
     process_result::HANDLED_TRUE | process_result::HANDLED_DEFERRED;
 
-// Occurrence of an event.
-// Event occurrences are placed in an event pool for later processing.
-class event_occurrence
-{
-    using process_fn_t = std::optional<process_result> (*)(
-        event_occurrence&, void* /*sm*/, uint16_t /*seq_cnt*/);
-
-  public:
-    event_occurrence(process_fn_t process_fn) : m_process_fn(process_fn)
-    {
-    }
-
-    // Try to process the event.
-    // A return value std::nullopt means that the conditions for processing
-    // were not given and the event has not been dispatched.
-    template <typename StateMachine>
-    std::optional<process_result> try_process(StateMachine& sm, uint16_t seq_cnt)
-    {
-        return m_process_fn(*this, static_cast<void*>(&sm), seq_cnt);
-    }
-
-    void mark_for_deletion()
-    {
-        m_marked_for_deletion = true;
-    }
-
-    bool marked_for_deletion() const
-    {
-        return m_marked_for_deletion;
-    }
-
-  private:
-    process_fn_t m_process_fn{};
-    // Flag set when this event has been processed and can be erased.
-    // Deletion is deferred to allow the use of std::deque,
-    // which provides better cache locality and lower per-element overhead.
-    bool m_marked_for_deletion{};
-};
-
-template <typename Event>
-class deferred_event : public event_occurrence
-{
-
-  public:
-    template <typename StateMachine>
-    deferred_event(StateMachine&, const Event& event, uint16_t seq_cnt) noexcept
-        : event_occurrence(&try_process<StateMachine>), m_seq_cnt(seq_cnt), m_event(event)
-    {
-    }
-
-    template <typename StateMachine>
-    static std::optional<process_result> try_process(event_occurrence& self, void* sm, uint16_t seq_cnt)
-    {
-        return static_cast<deferred_event*>(&self)
-            ->try_process_impl<StateMachine>(*reinterpret_cast<StateMachine*>(sm), seq_cnt);
-    }
-
-    template <typename StateMachine>
-    std::optional<process_result> try_process_impl(StateMachine& sm, uint16_t seq_cnt)
-    {
-        if ((m_seq_cnt == seq_cnt) || sm.is_event_deferred(m_event))
-        {
-            return std::nullopt;
-        }
-        mark_for_deletion();
-        return sm.process_event_internal(
-            m_event,
-            process_info::event_pool);
-    }
-
-  private:
-    uint16_t m_seq_cnt;
-    Event m_event;
-};
-
 template <typename Policy, typename = void>
 struct compile_policy_impl;
 
-} // boost::msm::backmp11::detail
+} // namespace boost::msm::backmp11::detail
 
 #endif // BOOST_MSM_BACKMP11_DETAIL_COMMON_HPP

--- a/include/boost/msm/backmp11/detail/event_pool_processor.hpp
+++ b/include/boost/msm/backmp11/detail/event_pool_processor.hpp
@@ -1,0 +1,201 @@
+// Copyright 2026 Christian Granzin
+// Copyright 2008 Christophe Henry
+// henry UNDERSCORE christophe AT hotmail DOT com
+// This is an extended version of the state machine available in the boost::mpl library
+// Distributed under the same license as the original.
+// Copyright for the original version:
+// Copyright 2005 David Abrahams and Aleksey Gurtovoy. Distributed
+// under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_MSM_BACKMP11_DETAIL_EVENT_POOL_PROCESSOR_HPP
+#define BOOST_MSM_BACKMP11_DETAIL_EVENT_POOL_PROCESSOR_HPP
+
+#include <cstdint>
+#include <optional>
+
+#include <boost/config.hpp>
+
+#include <boost/msm/backmp11/detail/common.hpp>
+#include <boost/msm/backmp11/state_machine_config.hpp>
+
+namespace boost::msm::backmp11::detail
+{
+
+// Occurrence of an event.
+// Event occurrences are placed in an event pool for later processing.
+class event_occurrence
+{
+  public:
+    using process_fn_t = std::optional<process_result> (*)(
+        event_occurrence&, void* /*processor*/, uint16_t /*seq_cnt*/);
+
+    event_occurrence(process_fn_t process_fn) : m_process_fn(process_fn)
+    {
+    }
+
+    // Try to process the event.
+    // A return value std::nullopt means that the conditions for processing
+    // were not given and the event has not been dispatched.
+    std::optional<process_result> try_process(void* processor, uint16_t seq_cnt)
+    {
+        return m_process_fn(*this, processor, seq_cnt);
+    }
+
+    void mark_for_deletion()
+    {
+        m_marked_for_deletion = true;
+    }
+
+    bool marked_for_deletion() const
+    {
+        return m_marked_for_deletion;
+    }
+
+  private:
+    process_fn_t m_process_fn{};
+    // Flag set when this event has been processed and can be erased.
+    // Deletion is deferred to allow the use of std::deque,
+    // which provides better cache locality and lower per-element overhead.
+    bool m_marked_for_deletion{};
+};
+
+template <typename Event>
+class deferred_event : public event_occurrence
+{
+  public:
+    template <typename StateMachine>
+    deferred_event(StateMachine&, const Event& event, uint16_t seq_cnt) noexcept
+        : event_occurrence(&try_process<StateMachine>), m_seq_cnt(seq_cnt),
+          m_event(event)
+    {
+    }
+
+    template <typename StateMachine>
+    static std::optional<process_result> try_process(event_occurrence& self,
+                                                     void* processor,
+                                                     uint16_t seq_cnt)
+    {
+        return static_cast<deferred_event&>(self)
+            .try_process_impl<StateMachine>(
+                static_cast<StateMachine&>(
+                    *static_cast<typename StateMachine::event_pool_processor*>(
+                        processor)),
+                seq_cnt);
+    }
+
+    template <typename StateMachine>
+    std::optional<process_result> try_process_impl(StateMachine& sm,
+                                                   uint16_t seq_cnt)
+    {
+        if ((m_seq_cnt == seq_cnt) || sm.is_event_deferred(m_event))
+        {
+            return std::nullopt;
+        }
+        mark_for_deletion();
+        return sm.process_event_internal(m_event, process_info::event_pool);
+    }
+
+  private:
+    uint16_t m_seq_cnt;
+    Event m_event;
+};
+
+template <template <typename> typename EventPoolContainer,
+          typename ProcessableEvent,
+          typename = void>
+class event_pool_processor
+{
+  protected:
+    static constexpr bool has_event_pool = true;
+    using processable_event = ProcessableEvent;
+    using event_pool_container_t = EventPoolContainer<processable_event>;
+
+    struct event_pool_t
+    {
+        event_pool_container_t events;
+        uint16_t cur_seq_cnt{};
+    };
+
+    event_pool_t& get_event_pool()
+    {
+        return this->m_event_pool;
+    }
+
+    const event_pool_t& get_event_pool() const
+    {
+        return this->m_event_pool;
+    }
+
+    // Core logic for event pool processing.
+    // Explicitly not inline, because code size can significantly increase if
+    // this method's content is inlined in all entries and process_event calls.
+    BOOST_NOINLINE size_t do_process_event_pool(size_t max_events)
+    {
+        size_t processed_events = 0;
+        auto it = m_event_pool.events.begin();
+        while (it != m_event_pool.events.end())
+        {
+            event_occurrence& event = **it;
+            // The event was already processed.
+            if (event.marked_for_deletion())
+            {
+                it = m_event_pool.events.erase(it);
+                continue;
+            }
+
+            std::optional<process_result> result =
+                event.try_process(this, m_event_pool.cur_seq_cnt);
+            // The event has not been dispatched.
+            if (!result.has_value())
+            {
+                it++;
+                continue;
+            }
+
+            // Consider anything except "only deferred" to be a processed event.
+            if (*result != process_result::HANDLED_DEFERRED)
+            {
+                processed_events++;
+                if (processed_events == max_events)
+                {
+                    break;
+                }
+            }
+
+            // Start from the beginning, we might be able to process
+            // events that were deferred before.
+            it = m_event_pool.events.begin();
+            // Consider newly deferred events only if
+            // the event was not deferred at the same time
+            // (required to prevent infinitely processing the same event,
+            // if it was handled and at the same time action-deferred
+            // in orthogonal regions).
+            if (!(*result & process_result::HANDLED_DEFERRED))
+            {
+                m_event_pool.cur_seq_cnt += 1;
+            }
+        }
+        return processed_events;
+    }
+
+  private:
+    event_pool_t m_event_pool;
+};
+
+template <template <typename> typename EventPoolContainer,
+          typename ProcessableEvent>
+class event_pool_processor<
+    EventPoolContainer,
+    ProcessableEvent,
+    std::enable_if_t<std::is_same_v<EventPoolContainer<ProcessableEvent>,
+                                    no_event_pool_container<ProcessableEvent>>>>
+{
+  protected:
+    static constexpr bool has_event_pool = false;
+};
+
+} // namespace boost::msm::backmp11::detail
+
+#endif // BOOST_MSM_BACKMP11_DETAIL_EVENT_POOL_PROCESSOR_HPP

--- a/include/boost/msm/backmp11/detail/history_impl.hpp
+++ b/include/boost/msm/backmp11/detail/history_impl.hpp
@@ -30,7 +30,7 @@ class history_impl<front::no_history, InitialStateIds>
     static void on_entry(StateMachine& sm, const Event&)
     {
         sm.m_active_state_ids = value_array<InitialStateIds>;
-        if constexpr (StateMachine::event_pool_member::value)
+        if constexpr (StateMachine::has_event_pool)
         {
             sm.get_event_pool().events.clear();
         }
@@ -77,7 +77,7 @@ class history_impl<front::shallow_history<Events...>, InitialStateIds>
         if constexpr (!mp11::mp_contains<events, Event>::value)
         {
             sm.m_active_state_ids = value_array<InitialStateIds>;
-            if constexpr (StateMachine::event_pool_member::value)
+            if constexpr (StateMachine::has_event_pool)
             {
                 sm.get_event_pool().events.clear();
             }

--- a/include/boost/msm/backmp11/detail/metafunctions.hpp
+++ b/include/boost/msm/backmp11/detail/metafunctions.hpp
@@ -55,23 +55,6 @@ constexpr bool mp_for_each_until(F &&func)
     return mp11::mp_apply<mp_for_each_until_impl, L>::invoke(std::forward<F>(func));
 }
 
-// Wrapper for an instance of a type, which might not be present.
-template<typename T, bool C>
-struct optional_instance;
-template <typename T>
-struct optional_instance<T, true>
-{
-    using type = T;
-    type instance;
-    static constexpr bool value = true;
-};
-template<typename T>
-struct optional_instance<T, false>
-{
-    using type = T;
-    static constexpr bool value = false;
-};
-
 // Helper to convert a single type or MPL sequence to Mp11
 template<typename T, typename Enable = void>
 struct to_mp_list

--- a/include/boost/msm/backmp11/detail/state_machine_base.hpp
+++ b/include/boost/msm/backmp11/detail/state_machine_base.hpp
@@ -20,54 +20,14 @@
 #include <boost/mp11.hpp>
 
 #include <boost/msm/row_tags.hpp>
-#include <boost/msm/backmp11/detail/basic_polymorphic.hpp>
 #include <boost/msm/backmp11/detail/favor_runtime_speed.hpp>
 #include <boost/msm/backmp11/detail/history_impl.hpp>
+#include <boost/msm/backmp11/detail/state_machine_core.hpp>
 #include <boost/msm/backmp11/detail/state_visitor.hpp>
 #include <boost/msm/backmp11/detail/transition_table.hpp>
-#include <boost/msm/backmp11/common_types.hpp>
-#include <boost/msm/backmp11/state_machine_config.hpp>
 
 namespace boost::msm::backmp11::detail
 {
-
-// Wrapper for not modifying T during copy and move operations.
-template <typename T>
-class non_propagating
-{
-  public:
-    non_propagating() = default;
-
-    explicit non_propagating(const T& value) : m_value(value)
-    {
-    }
-
-    non_propagating& operator=(const non_propagating&)
-    {
-        return *this;
-    }
-
-    non_propagating(non_propagating&&)
-    {
-    }
-
-    non_propagating& operator=(non_propagating&&)
-    {
-        return *this;
-    }
-
-    T& operator*()
-    {
-        return m_value;
-    }
-    const T& operator*() const
-    {
-        return m_value;
-    }
-
-  private:
-    T m_value;
-};
 
 // Wrapper to invoke a reflect free function
 // (required for ADL).
@@ -81,19 +41,23 @@ struct invoke_reflect_free
 };
 
 template <class FrontEnd, class Config, class Derived>
-class state_machine_base : public FrontEnd
+class state_machine_base
+    : public state_machine_core<
+          Config, get_nesting_role<Config, Derived>()>,
+      public FrontEnd
 {
+    using state_machine_core =
+        detail::state_machine_core<Config, get_nesting_role<Config, Derived>()>;
+    using event_pool_processor = typename state_machine_core::event_pool_processor;
+
     static_assert(
         is_composite<FrontEnd>::value,
         "FrontEnd must be a composite state");
-    static_assert(
-        is_config<Config>::value,
-        "Config must be an instance of state machine config");
 
   public:
-    using config_t = Config;
-    using root_sm_t = typename config_t::root_sm;
-    using context_t = typename config_t::context;
+    using config_t = typename state_machine_core::config_t;
+    using root_sm_t = typename state_machine_core::root_sm_t;
+    using context_t = typename state_machine_core::context_t;
     using front_end_t = FrontEnd;
     using derived_t = Derived;
     using starting = backmp11::starting;
@@ -193,42 +157,6 @@ class state_machine_base : public FrontEnd
 
     using states_t = mp11::mp_rename<typename internal::state_set, std::tuple>;
 
-  protected:
-    using processable_event = basic_polymorphic<event_occurrence>;
-    template <typename T>
-    using event_pool_container =
-        typename config_t::template event_pool_container<T>;
-    using event_pool_container_t = event_pool_container<processable_event>;
-
-    struct event_pool_t
-    {
-        event_pool_container_t events;
-        uint16_t cur_seq_cnt{};
-    };
-
-    using event_pool_member = optional_instance<
-        event_pool_t,
-        !std::is_same_v<event_pool_container<void>, no_event_pool_container<void>>>;
-
-    template <bool C = event_pool_member::value,
-              typename = std::enable_if_t<C>>
-    event_pool_t& get_event_pool()
-    {
-        return m_optional_members.template get<event_pool_member>();
-    }
-
-    template <bool C = event_pool_member::value,
-              typename = std::enable_if_t<C>>
-    const event_pool_t& get_event_pool() const
-    {
-        return m_optional_members.template get<event_pool_member>();
-    }
-
-    machine_state get_machine_state() const
-    {
-        return m_machine_state;
-    }
-
   private:
     using state_set = typename internal::state_set;
     using state_map = typename internal::state_map;
@@ -237,8 +165,7 @@ class state_machine_base : public FrontEnd
     using initial_state_ids =
         mp11::mp_transform<internal::template get_state_id,
                            typename internal::initial_states>;
-    using compile_policy = typename config_t::compile_policy;
-    using compile_policy_impl = detail::compile_policy_impl<compile_policy>;
+    using compile_policy_impl = detail::compile_policy_impl<typename config_t::compile_policy>;
 
     template <class, class, class>
     friend class state_machine_base;
@@ -252,15 +179,10 @@ class state_machine_base : public FrontEnd
     template <typename Policy, typename>
     friend struct detail::compile_policy_impl;
 
-    template <typename, typename, visit_mode, bool,
-              template <typename> typename...>
-    friend class state_visitor_impl;
     template <typename, bool, template <typename> typename...>
     friend class state_visitor_base_impl;
     template <typename, typename, template <typename> typename...>
     friend class event_deferral_visitor;
-    template <typename>
-    friend class init_state_visitor;
 
     template <typename Event>
     friend class deferred_event;
@@ -269,44 +191,10 @@ class state_machine_base : public FrontEnd
     friend void reflect(state_machine_base<T0, T1, T2>&, F&&);
     template<typename T0, typename T1, typename T2, typename F>
     friend void reflect(const state_machine_base<T0, T1, T2>&, F&&);
-
-    template <typename T>
-    using get_initial_event = typename T::initial_event;
-    using fsm_initial_event =
-        mp11::mp_eval_or<starting, get_initial_event, front_end_t>;
-
-    template <typename T>
-    using get_final_event = typename T::final_event;
-    using fsm_final_event =
-        mp11::mp_eval_or<stopping, get_final_event, front_end_t>;
     
     using history_impl = detail::history_impl<typename front_end_t::history,
                                               initial_state_ids>;
 
-    using context_member =
-        optional_instance<context_t*,
-                          !std::is_same_v<context_t, no_context> &&
-                              (std::is_same_v<root_sm_t, no_root_sm> ||
-                               std::is_same_v<root_sm_t, derived_t>)>;
-
-    // Visit states with a compile-time filter (reduces template instantiations).
-    // Kept private for now, because the API of this method is not stable yet
-    // and this optimization is likely not needed to be available in the public API.
-    template <visit_mode Mode, template <typename> typename... Predicates, typename Visitor>
-    void visit_if(Visitor&& visitor)
-    {
-        using state_visitor =
-            state_visitor<derived_t, Visitor, Mode, Predicates...>;
-        state_visitor::visit(self(), visitor);
-    }
-    template <visit_mode Mode, template <typename> typename... Predicates, typename Visitor>
-    void visit_if(Visitor&& visitor) const
-    {
-        using state_visitor =
-            state_visitor<const derived_t, Visitor, Mode, Predicates...>;
-        state_visitor::visit(self(), visitor);
-    }
-    
   public:
     // Construct and forward constructor arguments to the front-end.
     template <typename... Args>
@@ -325,31 +213,23 @@ class state_machine_base : public FrontEnd
         if constexpr (std::is_same_v<root_sm_t, no_root_sm> ||
                       std::is_same_v<root_sm_t, derived_t>)
         {
-            *m_root_sm = this;
+            *this->m_root_sm = this;
             using visitor_t = init_state_visitor<derived_t>;
             visitor_t visitor{self()};
             visit_if<visit_mode::all_recursive, 
-                     visitor_t::template predicate>(visitor);
+                     visitor_t::template predicate>(self(), visitor);
         }
     }
 
     // Construct with a context and
     // forward further constructor arguments to the front-end.
-    template <bool C = context_member::value,
+    template <bool C = state_machine_core::has_context_member,
               typename = std::enable_if_t<C>,
               typename... Args>
     state_machine_base(context_t& context, Args&&... args)
         : state_machine_base(std::forward<Args>(args)...)
     {
-        m_optional_members.template get<context_member>() = &context;
-        if constexpr (std::is_same_v<root_sm_t, no_root_sm>)
-        {
-            visit_if<visit_mode::all_recursive, has_state_machine_tag>(
-                [&context](auto& state_machine) {
-                    state_machine.m_optional_members
-                        .template get<context_member>() = &context;
-                });
-        }
+        this->m_context = &context;
     }
 
     // Copy constructor.
@@ -373,7 +253,7 @@ class state_machine_base : public FrontEnd
     // Start the state machine (calls entry of the initial state(s)).
     void start()
     {
-        start(fsm_initial_event{});
+        start(starting{});
     }
 
     // Start the state machine
@@ -388,7 +268,7 @@ class state_machine_base : public FrontEnd
             BOOST_ASSERT_MSG(&(this->get_root_sm()),
             "Root sm must be passed as Derived and configured as root_sm");
         }
-        if (m_machine_state == machine_state::stopped)
+        if (this->m_machine_state == machine_state::stopped)
         {
             on_entry(initial_event, get_fsm_argument());
         }
@@ -397,7 +277,7 @@ class state_machine_base : public FrontEnd
     // Stop the state machine (calls exit of the current state(s)).
     void stop()
     {
-        stop(fsm_final_event{});
+        stop(stopping{});
     }
 
     // Stop the state machine
@@ -405,7 +285,7 @@ class state_machine_base : public FrontEnd
     template <class Event>
     void stop(Event const& final_event)
     {
-        if (m_machine_state != machine_state::stopped)
+        if (this->m_machine_state != machine_state::stopped)
         {
             on_exit(final_event, get_fsm_argument());
         }
@@ -420,26 +300,11 @@ class state_machine_base : public FrontEnd
             process_info::direct_call);
     }
 
-    // Try to process pending event occurrences in the event pool,
-    // with an optional limit for the max no. of events that shall be processed.
-    // Returns the no. of processed events.
-    template <bool C = event_pool_member::value,
-              typename = std::enable_if_t<C>>
-    inline size_t process_event_pool(size_t max_events = SIZE_MAX)
-    {
-        if (get_event_pool().events.empty() ||
-            m_machine_state != machine_state::idle)
-        {
-            return 0;
-        }
-        return do_process_event_pool(max_events);
-    }
-
     // Enqueues an event in the event pool for later processing.
     // If the state machine is already processing, the event will be processed
     // after the current event completes.
     template <class Event,
-              bool C = event_pool_member::value,
+              bool C = state_machine_core::has_event_pool,
               typename = std::enable_if_t<C>>
     void enqueue_event(Event const& event)
     {
@@ -447,55 +312,24 @@ class state_machine_base : public FrontEnd
             *this, compile_policy_impl::normalize_event(event), false);
     }
 
-    // Get the context of the state machine.
-    template <bool C = !std::is_same_v<context_t, no_context>,
-              typename = std::enable_if_t<C>>
-    context_t& get_context()
+    // Puts the event into the event pool for later processing.
+    // If the deferral takes place while the state machine is processing,
+    // the event will be evaluated for dispatch from the next processing cycle.
+    template <
+        class Event,
+        bool C = state_machine_core::has_event_pool,
+        typename = std::enable_if_t<C>>
+    void defer_event(Event const& event)
     {
-        if constexpr (context_member::value)
-        {
-            return *m_optional_members.template get<context_member>();
-        }
-        else
-        {
-            return get_root_sm().get_context();
-        }
-    }
-
-    // Get the context of the state machine.
-    template <bool C = !std::is_same_v<context_t, no_context>,
-              typename = std::enable_if_t<C>>
-    const context_t& get_context() const
-    {
-        if constexpr (context_member::value)
-        {
-            return *m_optional_members.template get<context_member>();
-        }
-        else
-        {
-            return get_root_sm().get_context();
-        }
+        compile_policy_impl::defer_event(
+            *this, compile_policy_impl::normalize_event(event),
+            this->m_machine_state == machine_state::processing);
     }
 
     // Getter that returns the currently active state ids of the FSM.
     const active_state_ids_t& get_active_state_ids() const
     {
         return m_active_state_ids;
-    }
-
-    // Get the root sm.
-    template <typename T = root_sm_t, 
-              typename = std::enable_if_t<!std::is_same_v<T, no_root_sm>>>
-    root_sm_t& get_root_sm()
-    {
-        return *static_cast<root_sm_t*>(*m_root_sm);
-    }
-    // Get the root sm.
-    template <typename T = root_sm_t, 
-              typename = std::enable_if_t<!std::is_same_v<T, no_root_sm>>>
-    const root_sm_t& get_root_sm() const
-    {
-        return *static_cast<const root_sm_t*>(*m_root_sm);
     }
 
     // Return the id of a state in the sm.
@@ -515,12 +349,6 @@ class state_machine_base : public FrontEnd
             mp11::mp_map_contains<state_map, State>::value,
             "The state must be contained in the state machine");
         return detail::get_state_id<state_map, State>::value;
-    }
-
-    // True if the sm is used in another sm.
-    bool is_contained() const
-    {
-        return (static_cast<const void*>(this) != *m_root_sm);
     }
 
     // Get a state.
@@ -555,7 +383,7 @@ class state_machine_base : public FrontEnd
     template <visit_mode Mode, typename Visitor>
     void visit(Visitor&& visitor)
     {
-        visit_if<Mode>(std::forward<Visitor>(visitor));
+        visit_if<Mode>(self(), std::forward<Visitor>(visitor));
     }
 
     // Visit the states.
@@ -563,7 +391,7 @@ class state_machine_base : public FrontEnd
     template <visit_mode Mode, typename Visitor>
     void visit(Visitor&& visitor) const
     {
-        visit_if<Mode>(std::forward<Visitor>(visitor));
+        visit_if<Mode>(self(), std::forward<Visitor>(visitor));
     }
 
     // Check whether a state is currently active.
@@ -573,7 +401,7 @@ class state_machine_base : public FrontEnd
         using visitor_t = is_state_active_visitor<State>;
         visitor_t visitor;
         visit_if<visit_mode::active_recursive,
-                 visitor_t::template predicate>(visitor);
+                 visitor_t::template predicate>(self(), visitor);
         return visitor.result();
     }
 
@@ -584,22 +412,8 @@ class state_machine_base : public FrontEnd
         using visitor_t = is_flag_active_visitor<Flag, BinaryOp>;
         visitor_t visitor;
         visit_if<visit_mode::active_recursive,
-                 visitor_t::template predicate>(visitor);
+                 visitor_t::template predicate>(self(), visitor);
         return visitor.result();
-    }
-
-    // Puts the event into the event pool for later processing.
-    // If the deferral takes place while the state machine is processing,
-    // the event will be evaluated for dispatch from the next processing cycle.
-    template <
-        class Event,
-        bool C = event_pool_member::value,
-        typename = std::enable_if_t<C>>
-    void defer_event(Event const& event)
-    {
-        compile_policy_impl::defer_event(
-            *this, compile_policy_impl::normalize_event(event),
-            m_machine_state == machine_state::processing);
     }
 
   protected:
@@ -622,7 +436,7 @@ class state_machine_base : public FrontEnd
         }
         else
         {
-            return get_root_sm();
+            return this->get_root_sm();
         }
     }
 
@@ -655,13 +469,10 @@ class state_machine_base : public FrontEnd
     }
 
     // Main function used internally to process events.
-    // Explicitly not inline, because code size can significantly increase if
-    // this method is inlined in all existing process_info variants.
     template <class Event>
-    BOOST_NOINLINE process_result process_event_internal(Event const& event,
-                                                         process_info info)
+    process_result process_event_internal(Event const& event, process_info info)
     {
-        if (m_machine_state != machine_state::idle)
+        if (this->m_machine_state != machine_state::idle)
         {
             return process_result::HANDLED_FALSE;
         }
@@ -684,7 +495,7 @@ class state_machine_base : public FrontEnd
             }
         }
 
-        if constexpr (event_pool_member::value)
+        if constexpr (state_machine_core::has_event_pool)
         {
             if (info != process_info::event_pool)
             {
@@ -700,24 +511,24 @@ class state_machine_base : public FrontEnd
 
                 // Ensure we consider an event
                 // that was action-deferred in the last sequence.
-                get_event_pool().cur_seq_cnt += 1;
+                this->get_event_pool().cur_seq_cnt += 1;
             }
         }
 
         // Process the event.
         process_result result;
         {
-            process_guard guard{m_machine_state};
+            process_guard guard{this->m_machine_state};
             result = do_process_event(event, info);
         }
 
         // After handling, look if we have more to process in the event pool
         // (but only if we're not already processing from it).
-        if constexpr (event_pool_member::value)
+        if constexpr (state_machine_core::has_event_pool)
         {
             if (info != process_info::event_pool)
             {
-                process_event_pool();
+                this->process_event_pool();
             }
         }
 
@@ -795,19 +606,22 @@ class state_machine_base : public FrontEnd
         {
         }
 
-        static std::optional<process_result> try_process(event_occurrence& self, void* sm, uint16_t /*seq_cnt*/)
+        static std::optional<process_result> try_process(
+            event_occurrence& self, void* processor,
+            uint16_t /*seq_cnt*/)
         {
-            return static_cast<completion_event_occurrence*>(&self)
-                ->try_process_impl(*reinterpret_cast<derived_t*>(sm));
+            return static_cast<completion_event_occurrence&>(self)
+                .try_process_impl(static_cast<derived_t&>(
+                    *static_cast<event_pool_processor*>(processor)));
         }
 
       private:
-            std::optional<process_result> try_process_impl(derived_t& sm)
-            {
-                mark_for_deletion();
-                return sm.template
-                    process_completion_transition<completion_transition>(m_region_id);
-            }
+        std::optional<process_result> try_process_impl(derived_t& sm)
+        {
+            mark_for_deletion();
+            return sm.template process_completion_transition<
+                completion_transition>(m_region_id);
+        }
 
         uint8_t m_region_id;
     };
@@ -819,7 +633,8 @@ class state_machine_base : public FrontEnd
         if constexpr (mp11::mp_any_of<state_set, is_state_blocking>::value)
         {
             // If the state machine is interrupted or terminated, do not handle any event.
-            if (is_flag_active<TerminateFlag>() || is_flag_active<InterruptedFlag>())
+            if (is_flag_active<TerminateFlag>() ||
+                is_flag_active<InterruptedFlag>())
             {
                 return process_result::HANDLED_TRUE;
             }
@@ -828,74 +643,18 @@ class state_machine_base : public FrontEnd
         // Process the event.
         using completion_event = typename Transition::transition_event;
         {
-            process_guard guard{m_machine_state};
+            process_guard guard{this->m_machine_state};
             return Transition::execute(self(), region_id, completion_event{});
         }
-    }
-
-    // Core logic for event pool processing,
-    // there must be at least one event in the pool.
-    // Explicitly not inline, because code size can significantly increase if
-    // this method's content is inlined in all entries and process_event calls.
-    template <bool C = event_pool_member::value,
-              typename = std::enable_if_t<C>>
-    BOOST_NOINLINE size_t do_process_event_pool(size_t max_events = SIZE_MAX)
-    {
-        event_pool_t& event_pool = get_event_pool();
-        auto it = event_pool.events.begin();
-        size_t processed_events = 0;
-        do
-        {
-            event_occurrence& event = **it;
-            // The event was already processed.
-            if (event.marked_for_deletion())
-            {
-                it = event_pool.events.erase(it);
-                continue;
-            }
-
-            std::optional<process_result> result =
-                event.try_process(self(), event_pool.cur_seq_cnt);
-            // The event has not been dispatched.
-            if (!result.has_value())
-            {
-                it++;
-                continue;
-            }
-
-            // Consider anything except "only deferred" to be a processed event.
-            if (*result != process_result::HANDLED_DEFERRED)
-            {
-                processed_events++;
-                if (processed_events == max_events)
-                {
-                    break;
-                }
-            }
-
-            // Start from the beginning, we might be able to process
-            // events that were deferred before.
-            it = event_pool.events.begin();
-            // Consider newly deferred events only if
-            // the event was not deferred at the same time
-            // (required to prevent infinitely processing the same event,
-            // if it was handled and at the same time action-deferred
-            // in orthogonal regions).
-            if (!(*result & process_result::HANDLED_DEFERRED))
-            {
-                event_pool.cur_seq_cnt += 1;
-            }
-        } while (it != event_pool.events.end());
-        return processed_events;
     }
 
     template <class Event>
     void do_defer_event(const Event& event, bool next_rtc_seq)
     {
-        auto& event_pool = get_event_pool();
+        auto& event_pool = this->get_event_pool();
         const uint16_t seq_cnt = next_rtc_seq ? event_pool.cur_seq_cnt
                                               : event_pool.cur_seq_cnt - 1;
-        event_pool.events.push_back(processable_event::make(
+        event_pool.events.push_back(event_pool_processor::processable_event::make(
             deferred_event<Event>{self(), event, seq_cnt}));
     }
 
@@ -926,7 +685,7 @@ class state_machine_base : public FrontEnd
     void on_entry(Event const& event, Fsm& fsm)
     {
         {
-            process_guard guard{m_machine_state};
+            process_guard guard{this->m_machine_state};
 
             // First set all active state ids...
             history_impl::on_entry(self(), event);
@@ -938,9 +697,9 @@ class state_machine_base : public FrontEnd
         }
 
         // After handling, look if we have more to process in the event pool.
-        if constexpr (event_pool_member::value)
+        if constexpr (state_machine_core::has_event_pool)
         {
-            process_event_pool();
+            this->process_event_pool();
         }
     }
 
@@ -948,7 +707,7 @@ class state_machine_base : public FrontEnd
     void on_explicit_entry(Event const& event, Fsm& fsm)
     {
         {
-            process_guard guard{m_machine_state};
+            process_guard guard{this->m_machine_state};
 
             // First set all active state ids...
             using state_identities =
@@ -988,9 +747,9 @@ class state_machine_base : public FrontEnd
         }
 
         // After handling, look if we have more to process in the event pool.
-        if constexpr (event_pool_member::value)
+        if constexpr (state_machine_core::has_event_pool)
         {
-            process_event_pool();
+            this->process_event_pool();
         }
     }
 
@@ -1013,11 +772,11 @@ class state_machine_base : public FrontEnd
             !is_composite<State>::value &&
             has_completion_transitions<derived_t, State>::value)
         {
-            auto& event_pool = get_event_pool();
+            auto& event_pool = this->get_event_pool();
             // Process completion transitions BEFORE any other event in the
             // pool (UML Standard 2.3 15.3.14).
             event_pool.events.push_front(
-                processable_event::make(
+                event_pool_processor::processable_event::make(
                     completion_event_occurrence<State>{region_id}));
         }
     }
@@ -1026,7 +785,7 @@ class state_machine_base : public FrontEnd
     void on_exit(Event const& event, Fsm& fsm)
     {
         {
-            process_guard guard{m_machine_state};
+            process_guard guard{this->m_machine_state};
 
             // First exit the substates...
             visit<visit_mode::active_non_recursive>(
@@ -1037,7 +796,7 @@ class state_machine_base : public FrontEnd
             // ... then call our own exit.
             (static_cast<front_end_t*>(this))->on_exit(event, fsm);
         }
-        m_machine_state = machine_state::stopped;
+        this->m_machine_state = machine_state::stopped;
     }
 
     derived_t& self()
@@ -1129,27 +888,8 @@ class state_machine_base : public FrontEnd
         reflect_impl(*this, std::forward<Visitor>(visitor));
     }
 
-    struct optional_members :
-        event_pool_member,
-        context_member
-    {
-        template <typename T>
-        typename T::type& get()
-        {
-            return static_cast<T*>(this)->instance;
-        }
-        template <typename T>
-        const typename T::type& get() const
-        {
-            return static_cast<const T*>(this)->instance;
-        }
-    };
-
-    non_propagating<void*> m_root_sm{nullptr};
-    optional_members       m_optional_members{};
     states_t               m_states{};
     active_state_ids_t     m_active_state_ids{value_array<initial_state_ids>};
-    machine_state          m_machine_state{machine_state::stopped};
 };
 
 std::false_type is_state_machine(...);

--- a/include/boost/msm/backmp11/detail/state_machine_core.hpp
+++ b/include/boost/msm/backmp11/detail/state_machine_core.hpp
@@ -1,0 +1,241 @@
+// Copyright 2026 Christian Granzin
+// Copyright 2008 Christophe Henry
+// henry UNDERSCORE christophe AT hotmail DOT com
+// This is an extended version of the state machine available in the boost::mpl library
+// Distributed under the same license as the original.
+// Copyright for the original version:
+// Copyright 2005 David Abrahams and Aleksey Gurtovoy. Distributed
+// under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_MSM_BACKMP11_DETAIL_STATE_MACHINE_CORE_HPP
+#define BOOST_MSM_BACKMP11_DETAIL_STATE_MACHINE_CORE_HPP
+
+#include <cstdint>
+
+#include <boost/msm/backmp11/detail/metafunctions.hpp>
+#include <boost/msm/backmp11/detail/basic_polymorphic.hpp>
+#include <boost/msm/backmp11/detail/event_pool_processor.hpp>
+
+namespace boost::msm::backmp11::detail
+{
+
+// Wrapper for not modifying T during copy and move operations.
+template <typename T>
+class non_propagating
+{
+  public:
+    non_propagating() = default;
+
+    explicit non_propagating(const T& value) : m_value(value)
+    {
+    }
+
+    non_propagating& operator=(const non_propagating&)
+    {
+        return *this;
+    }
+
+    non_propagating(non_propagating&&)
+    {
+    }
+
+    non_propagating& operator=(non_propagating&&)
+    {
+        return *this;
+    }
+
+    T& operator*()
+    {
+        return m_value;
+    }
+    const T& operator*() const
+    {
+        return m_value;
+    }
+
+  private:
+    T m_value;
+};
+
+enum class nesting_role
+{
+    root,
+    nested,
+    unknown
+};
+
+template <typename Config, typename Derived>
+constexpr nesting_role get_nesting_role()
+{
+    if constexpr (std::is_same_v<typename Config::root_sm, no_root_sm>)
+    {
+        return nesting_role::unknown;
+    }
+    else if constexpr (std::is_same_v<typename Config::root_sm, Derived>)
+    {
+        return nesting_role::root;
+    }
+    else
+    {
+        return nesting_role::nested;
+    }
+}
+
+constexpr nesting_role get_root_nesting_role(nesting_role value)
+{
+    switch (value)
+    {
+    case nesting_role::root:
+    case nesting_role::nested:
+        return nesting_role::root;
+    case nesting_role::unknown:
+        return nesting_role::unknown;
+    }
+}
+
+template <typename Context, nesting_role NestingRole>
+class context_member
+{
+  protected:
+    static constexpr bool has_context_member = true;
+
+  private:
+    template <typename, typename, typename>
+    friend class state_machine_base;
+    template <typename, nesting_role>
+    friend class state_machine_core;
+
+    Context* m_context;
+};
+
+template <typename Context>
+class context_member<Context, nesting_role::nested>
+{
+  protected:
+    static constexpr bool has_context_member = false;
+};
+
+template <>
+class context_member<no_context, nesting_role::root>
+{
+  protected:
+    static constexpr bool has_context_member = false;
+};
+
+template <>
+class context_member<no_context, nesting_role::unknown>
+{
+  protected:
+    static constexpr bool has_context_member = false;
+};
+
+template <typename Config, nesting_role NestingRole>
+class state_machine_core
+    : public event_pool_processor<Config::template event_pool_container,
+                                  basic_polymorphic<event_occurrence>>,
+      public context_member<typename Config::context, NestingRole>
+{
+  public:
+    using config_t = Config;
+    using root_sm_t = typename Config::root_sm;
+    using context_t = typename Config::context;
+
+    // Get the context of the state machine.
+    template <bool C = !std::is_same_v<context_t, no_context>,
+              typename = std::enable_if_t<C>>
+    context_t& get_context()
+    {
+        return const_cast<context_t&>(std::as_const(*this).get_context());
+    }
+
+    // Get the context of the state machine.
+    template <bool C = !std::is_same_v<context_t, no_context>,
+              typename = std::enable_if_t<C>>
+    const context_t& get_context() const
+    {
+        if constexpr (NestingRole == nesting_role::root)
+        {
+            return *this->m_context;
+        }
+        else
+        {
+            return *(*m_root_sm)->m_context;
+        }
+    }
+
+    // Try to process pending event occurrences in the event pool,
+    // with an optional limit for the max no. of events that shall be processed.
+    // Returns the no. of processed events.
+    template <bool C = state_machine_core::has_event_pool,
+              typename = std::enable_if_t<C>>
+    inline size_t process_event_pool(size_t max_events = SIZE_MAX)
+    {
+        if (this->get_event_pool().events.empty() ||
+            get_machine_state() != machine_state::idle)
+        {
+            return 0;
+        }
+        return this->do_process_event_pool(max_events);
+    }
+
+    // Get the root sm.
+    template <bool C = !std::is_same_v<root_sm_t, no_root_sm>,
+              typename = std::enable_if_t<C>>
+    root_sm_t& get_root_sm()
+    {
+        return *static_cast<root_sm_t*>(*m_root_sm);
+    }
+    // Get the root sm.
+    template <bool C = !std::is_same_v<root_sm_t, no_root_sm>,
+              typename = std::enable_if_t<C>>
+    const root_sm_t& get_root_sm() const
+    {
+        return *static_cast<const root_sm_t*>(*m_root_sm);
+    }
+
+    // True if the sm is used in another sm.
+    bool is_contained() const
+    {
+        return (static_cast<const void*>(this) != *m_root_sm);
+    }
+
+  protected:
+    machine_state get_machine_state() const
+    {
+        return m_machine_state;
+    }
+
+  private:
+    template <typename, nesting_role>
+    friend class state_machine_core;
+    template <typename, typename, typename>
+    friend class state_machine_base;
+    template <typename, typename, visit_mode, bool,
+              template <typename> typename...>
+    friend class state_visitor_impl;
+    template <typename>
+    friend class init_state_visitor;
+    template <typename, typename, template <typename> typename...>
+    friend class event_deferral_visitor;
+    template <typename StateMachine>
+    friend struct transition_table_impl;
+
+    using event_pool_processor =
+        detail::event_pool_processor<Config::template event_pool_container,
+                                     basic_polymorphic<event_occurrence>>;
+    using root_sm_core =
+        state_machine_core<Config, get_root_nesting_role(NestingRole)>;
+
+    static_assert(
+        is_config<Config>::value,
+        "Config must be an instance of state machine config");
+
+    non_propagating<root_sm_core*> m_root_sm{nullptr};
+    machine_state                  m_machine_state{machine_state::stopped};
+};
+
+} // namespace boost::msm::backmp11::detail
+
+#endif // BOOST_MSM_BACKMP11_DETAIL_STATE_MACHINE_CORE_HPP

--- a/include/boost/msm/backmp11/detail/state_visitor.hpp
+++ b/include/boost/msm/backmp11/detail/state_visitor.hpp
@@ -128,6 +128,10 @@ struct recursive_visit_set<StateMachine, FirstPredicate, Predicate>
     using needs_traversal = mp11::mp_not<mp11::mp_empty<states_to_traverse>>;
 };
 
+template <visit_mode Mode, template <typename> typename... Predicates,
+          typename StateMachine, typename Visitor>
+void visit_if(StateMachine& sm, Visitor&& visitor);
+
 template <typename StateMachine,
           template <typename> typename... Predicates>
 class state_visitor_base_impl<
@@ -155,7 +159,7 @@ class state_visitor_base_impl<
                           typename visit_set::submachines_to_traverse,
                           State>::value)
         {
-            state.template visit_if<Mode, Predicates...>(visitor);
+            visit_if<Mode, Predicates...>(state, visitor);
         }
     }
 };
@@ -200,7 +204,7 @@ class state_visitor_impl<
                 using state_identities = mp11::mp_transform<
                             mp11::mp_identity,
                             typename base::states_to_traverse>;
-                for (const auto active_state_id : sm.m_active_state_ids)
+                for (const auto active_state_id : sm.get_active_state_ids())
                 {
                     mp11::mp_for_each<state_identities>(
                         [&sm, &visitor, active_state_id](auto state_identity)
@@ -294,7 +298,7 @@ class event_deferral_visitor
             using state_identities = mp11::mp_transform<
                         mp11::mp_identity,
                         typename visit_set::states_to_traverse>;
-            for (const auto active_state_id : sm.m_active_state_ids)
+            for (const auto active_state_id : sm.get_active_state_ids())
             {
                 mp11::mp_for_each<state_identities>(
                     [&sm, &visitor, active_state_id](auto state_identity)
@@ -332,6 +336,16 @@ class event_deferral_visitor
         }
     }
 };
+
+// Visit states with a compile-time filter (reduces template instantiations).
+template <visit_mode Mode, template <typename> typename... Predicates,
+          typename StateMachine, typename Visitor>
+void visit_if(StateMachine& sm, Visitor&& visitor)
+{
+    using state_visitor =
+        state_visitor<StateMachine, Visitor, Mode, Predicates...>;
+    state_visitor::visit(sm, visitor);
+}
 
 // Predefined visitor functors used in backmp11.
 
@@ -450,8 +464,8 @@ class init_state_visitor
                 std::is_same_v<typename State::context_t, no_context> ||
                 std::is_same_v<typename State::context_t, typename RootSm::context_t>,
                 "The configured context must match the root sm's one");
-            static_assert(std::is_same_v<typename RootSm::compile_policy,
-                                         typename State::compile_policy>,
+            static_assert(std::is_same_v<typename RootSm::config_t::compile_policy,
+                                         typename State::config_t::compile_policy>,
                           "All compile policies must be identical");
 
             *state.m_root_sm = &m_root_sm;

--- a/include/boost/msm/backmp11/detail/transition_table.hpp
+++ b/include/boost/msm/backmp11/detail/transition_table.hpp
@@ -447,12 +447,9 @@ struct transition_table_impl
     using has_completion_event = has_completion_event<typename Transition::transition_event>;
     using completion_transition_table =
         mp11::mp_copy_if<transition_table, has_completion_event>;
-    static_assert(
-        mp11::mp_empty<completion_transition_table>::value ||
-            !std::is_same_v<
-                typename StateMachine::template event_pool_container<void>,
-                no_event_pool_container<void>>,
-        "Completion transitions require an event pool");
+    static_assert(mp11::mp_empty<completion_transition_table>::value ||
+                      StateMachine::has_event_pool,
+                  "Completion transitions require an event pool");
     template <typename State, typename Table = completion_transition_table>
     struct completion_transitions_impl
     {

--- a/include/boost/msm/backmp11/favor_compile_time.hpp
+++ b/include/boost/msm/backmp11/favor_compile_time.hpp
@@ -40,11 +40,7 @@
 namespace boost:: msm::backmp11
 {
 
-struct favor_compile_time
-{
-    // TODO fix adapter and remove this.
-    using compile_policy = int;
-};
+struct favor_compile_time {};
 
 namespace detail
 {

--- a/include/boost/msm/backmp11/state_machine_config.hpp
+++ b/include/boost/msm/backmp11/state_machine_config.hpp
@@ -45,11 +45,11 @@ struct no_root_sm {};
 
 // Config for the default fsm parameter
 // (local transition owner).
-struct local_transition_owner{};
+struct local_transition_owner {};
 
 // Config for disabling the event pool.
 template <typename T>
-struct no_event_pool_container;
+struct no_event_pool_container {};
 
 // Default state machine config.
 struct default_state_machine_config

--- a/test/Backmp11Adapter.hpp
+++ b/test/Backmp11Adapter.hpp
@@ -85,48 +85,49 @@ class serializer
 
 using back::queue_container_deque;
 
-template <
-    class A1,
-    class A2,
-    class A3,
-    class A4
->
+template <typename CompilePolicy, typename QueueContainerPolicy>
 struct state_machine_config_adapter : state_machine_config
 {
-    typedef ::boost::parameter::parameters<
-      ::boost::parameter::optional<
-            ::boost::parameter::deduced< back::tag::history_policy>, has_history_policy< ::boost::mpl::_ >
-        >
-    , ::boost::parameter::optional<
-            ::boost::parameter::deduced< back::tag::compile_policy>, has_compile_policy< ::boost::mpl::_ >
-        >
-    , ::boost::parameter::optional<
-            ::boost::parameter::deduced< back::tag::fsm_check_policy>, has_fsm_check< ::boost::mpl::_ >
-        >
-    , ::boost::parameter::optional<
-            ::boost::parameter::deduced< back::tag::queue_container_policy>,
-            has_queue_container_policy< ::boost::mpl::_ >
-        >
-    > config_signature;
-
-    typedef typename
-        config_signature::bind<A1,A2,A3,A4>::type
-        config_args;
-
-    typedef typename ::boost::parameter::binding<
-        config_args, back::tag::compile_policy, favor_runtime_speed >::type    CompilePolicy;
     using compile_policy = mp11::mp_if_c<
         std::is_same_v<CompilePolicy, favor_runtime_speed>,
         favor_runtime_speed,
         favor_compile_time>;
     
-
-    typedef typename ::boost::parameter::binding<
-        config_args, back::tag::queue_container_policy,
-        queue_container_deque >::type                                    QueueContainerPolicy;
-    template<typename T>
-    using queue_container = typename QueueContainerPolicy::template In<T>::type;
+    template <typename T>
+    using event_pool_container = typename QueueContainerPolicy::template In<T>::type;
 };
+
+template <class A1, class A2, class A3, class A4>
+struct get_state_machine_config_adapter_impl
+{
+    using config_signature = parameter::parameters<
+        parameter::optional<parameter::deduced<back::tag::history_policy>,
+                            has_history_policy<mpl::_>>,
+        parameter::optional<parameter::deduced<back::tag::compile_policy>,
+                            has_compile_policy<mpl::_>>,
+        parameter::optional<parameter::deduced<back::tag::fsm_check_policy>,
+                            has_fsm_check<mpl::_>>,
+        parameter::optional<parameter::deduced<back::tag::queue_container_policy>,
+                            has_queue_container_policy<mpl::_>>>;
+
+    using config_args = typename config_signature::bind<A1, A2, A3, A4>::type;
+
+    using CompilePolicy =
+        typename parameter::binding<config_args,
+                                    back::tag::compile_policy,
+                                    favor_runtime_speed>::type;
+
+    using QueueContainerPolicy =
+        typename parameter::binding<config_args,
+                                    back::tag::queue_container_policy,
+                                    queue_container_deque>::type;
+
+    using type =
+        state_machine_config_adapter<CompilePolicy, QueueContainerPolicy>;
+};
+template <class A1, class A2, class A3, class A4>
+using get_state_machine_config_adapter =
+    typename get_state_machine_config_adapter_impl<A1, A2, A3, A4>::type;
 
 template <class A0,
           class A1 = parameter::void_,
@@ -134,9 +135,15 @@ template <class A0,
           class A3 = parameter::void_,
           class A4 = parameter::void_>
 class state_machine_adapter
-    : public state_machine<A0, state_machine_config_adapter<A1, A2, A3, A4>, state_machine_adapter<A0, A1, A2, A3, A4>>
+    : public state_machine<A0,
+                           get_state_machine_config_adapter<A1, A2, A3, A4>,
+                           state_machine_adapter<A0, A1, A2, A3, A4>>
 {
-    using Base = state_machine<A0, state_machine_config_adapter<A1, A2, A3, A4>, state_machine_adapter<A0, A1, A2, A3, A4>>;
+    using Base =
+        state_machine<A0,
+                      get_state_machine_config_adapter<A1, A2, A3, A4>,
+                      state_machine_adapter<A0, A1, A2, A3, A4>>;
+
   public:
     using Base::Base;
 


### PR DESCRIPTION
Refactor core parts of the state machine back-end:

Preparation for better observer support with a single observer instance in nested machines, by providing access to members of the root machine's core without knowing its exact type.

Also resulted in re-usable event pool code in hierarchical state machines, which improved binary size and execution time. The method `process_event_pool_internal(...)` is not forced to be non-inline anymore, giving the compiler more freedom to optimize based on the selected build mode.